### PR TITLE
Change tx step for ZhiJia based codecs

### DIFF
--- a/custom_components/ble_adv/codecs/models.py
+++ b/custom_components/ble_adv/codecs/models.py
@@ -340,6 +340,8 @@ class BleAdvCodec(ABC):
     """Class representing a base encoder / decoder."""
 
     _len: int = 0
+    _tx_step: int = 1
+    _tx_max: int = 125
 
     def __init__(self) -> None:
         self.codec_id: str | None = None
@@ -439,6 +441,7 @@ class BleAdvCodec(ABC):
 
     def encode_adv(self, enc_cmd: BleAdvEncCmd, conf: BleAdvConfig) -> BleAdvAdvertisement:
         """Encode an Encoder Command with Config into an Adv."""
+        conf.tx_count = (conf.tx_count + self._tx_step) % self._tx_max
         read_buffer = self.convert_from_enc(enc_cmd, conf)
         self.log_buffer(read_buffer, "Encode/Decrypted")
         encrypted = self._header + self.encrypt(self._prefix + read_buffer)

--- a/custom_components/ble_adv/codecs/zhijia.py
+++ b/custom_components/ble_adv/codecs/zhijia.py
@@ -112,6 +112,7 @@ class ZhijiaEncoderV1(ZhijiaEncoder):
 
     _pivot_index: frozenset[int] = frozenset({2, 4, 9, 12, 13, 15})
     _len = 23
+    _tx_step = 2
     _pivot_xor = True
 
     def __init__(self, mac: list[int]) -> None:
@@ -379,7 +380,7 @@ TRANS_VR1 = [
     Trans(LightCmd().act(ATTR_ON, True), EncCmd(0xA5)),
     Trans(LightCmd().act(ATTR_ON, False), EncCmd(0xA6)),
     Trans(CTLightCmd().act(ATTR_COLD).act(ATTR_WARM), EncCmd(0xA8)).copy(ATTR_COLD, "arg0", 250).copy(ATTR_WARM, "arg1", 250),
-    #  Missing: AF / A7 / A9 / AC / AB / AA
+    # //  Missing: AF / A7 / A9 / AC / AB / AA
 ]
 
 CODECS = [
@@ -395,16 +396,3 @@ CODECS = [
     # Zhi Jia Remote
     ZhijiaEncoderRemote([0x20, 0x03, 0x05]).id("zhijia_vr1").header([0xF0, 0xFF]).ble(0x1A, 0xFF).add_translators(TRANS_VR1),
 ]  # fmt: skip
-
-# ruff: noqa: ERA001
-# "zhijia": {
-#     "variants": {
-#         "v2_fl": {  # to resolve flickering issues
-#             "class": "ZhijiaEncoderV2",
-#             "translator": "default_translator_zjv2fl",
-#             "args": [[0x19, 0x01, 0x10]],
-#             "max_forced_id": 0xFFFFFF,
-#             "ble_param": [0x1A, 0xFF],
-#             "header": [0x22, 0x9D],
-#         },
-#     },

--- a/custom_components/ble_adv/device.py
+++ b/custom_components/ble_adv/device.py
@@ -294,7 +294,6 @@ class BleAdvDevice(BleAdvMatchingDevice):
             enc_cmds = acodec.ent_to_enc(ent_attr)
             for enc_cmd in enc_cmds:
                 self.logger.debug(f"Cmd: {enc_cmd}")
-                self.config.tx_count = (self.config.tx_count + 1) % 125
                 adv: BleAdvAdvertisement = acodec.encode_adv(enc_cmd, self.config)
                 qi: BleAdvQueueItem = BleAdvQueueItem(enc_cmd.cmd, self.repeat, self.duration, self.interval, adv.to_raw())
                 await self.coordinator.advertise(self.adapter_id, self.unique_id, qi)

--- a/tests/codecs/__init__.py
+++ b/tests/codecs/__init__.py
@@ -5,6 +5,10 @@ from ble_adv.codecs import get_codecs
 from ble_adv.codecs.models import BleAdvAdvertisement, BleAdvCodec
 
 CODECS: dict[str, BleAdvCodec] = get_codecs()
+# Disable tx_count bump by codecs
+for codec in CODECS.values():
+    codec._tx_step = 0  # noqa: SLF001
+    codec._tx_max = 256  # noqa: SLF001
 
 
 def _from_dotted(data: str) -> bytes:

--- a/tests/codecs/test_models.py
+++ b/tests/codecs/test_models.py
@@ -99,6 +99,8 @@ def test_ent_attr() -> None:
 def test_config() -> None:
     """Test BleAdvConfig."""
     conf = BleAdvConfig(12, 1)
+    assert conf.tx_count == 0
+    assert conf.seed == 0
     conf.seed = 0x12
     conf.tx_count = 2
     assert repr(conf) == "id: 0x0000000C, index: 1, tx: 2, seed: 0x0012"
@@ -279,7 +281,9 @@ def test_codec() -> None:
         {ATTR_ON: {False, True}, ATTR_SUB_TYPE: {LIGHT_TYPE_ONOFF, LIGHT_TYPE_CWW, LIGHT_TYPE_RGB}},
         {ATTR_ON: {False, True}, ATTR_SUB_TYPE: {LIGHT_TYPE_ONOFF}},
     ]
-    assert repr(codec.encode_adv(BleAdvEncCmd(0x10), BleAdvConfig())) == "Type: 0x16, raw: 55.56.74.65.73.74"
+    conf = BleAdvConfig()
+    assert repr(codec.encode_adv(BleAdvEncCmd(0x10), conf)) == "Type: 0x16, raw: 55.56.74.65.73.74"
+    assert conf.tx_count == 1
     assert codec.decode_adv(BleAdvAdvertisement(0x16, _from_dotted("55.56.74.65.73.74"))) == (BleAdvEncCmd(0x10), BleAdvConfig())
     assert codec.decode_adv(BleAdvAdvertisement(0x16, _from_dotted("00.00.74.65.73.74"))) == (None, None)
     assert codec.decode_adv(BleAdvAdvertisement(0x00, _from_dotted("55.56.74.65.73.74"))) == (None, None)


### PR DESCRIPTION
Add the possibility to change the way the tx is increased by a codec.
for ZhiJiaV1 / ZhijiaV2 base codec, increase the tx by 2 instead of 1, as done by the Android Phone App.