### PR TITLE
Adapt repeat to the adapter

### DIFF
--- a/custom_components/ble_adv/__init__.py
+++ b/custom_components/ble_adv/__init__.py
@@ -134,7 +134,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.title,
         device_conf[CONF_CODEC_ID],
         tech_conf[CONF_ADAPTER_IDS],
-        tech_conf[CONF_REPEAT],
+        3 * tech_conf[CONF_REPEAT],
         tech_conf[CONF_INTERVAL],
         tech_conf[CONF_DURATION],
         BleAdvConfig(device_conf[CONF_FORCED_ID], device_conf[CONF_INDEX]),


### PR DESCRIPTION
Adapt how the repetition of the adv is sent and handled by the adapter:
* hci adapter is sending advs by bunch of 60ms
* ble_adv_proxy adapters is sending advs by bunch of 100ms

The total number of repetition is splitted accordingly and based on  interval in between advs:
* interval 20ms / repeat 9 => 3 bunchs of 3 advs for hci, 2 bunchs of 5 advs for esp