### PR TITLE
Fix 100% CPU event-loop spin on a stuck-readable HCI socket (EAGAIN after select)

### DIFF
--- a/custom_components/ble_adv/async_socket/__init__.py
+++ b/custom_components/ble_adv/async_socket/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import pickle
+import select
 import socket
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Coroutine
@@ -151,7 +152,49 @@ class AsyncSocket(AsyncSocketBase):
         """Receive Data from socket."""
         if self._socket is None:
             return None, False
-        data = await asyncio.get_event_loop().sock_recv(self._socket, 4096)
+        # Not loop.sock_recv(): when the controller is reset out from under us by
+        # another stack sharing the adapter (host bluetoothd toggling power, or a
+        # desktop logout emitting mgmt NEW_SETTINGS), the selector keeps reporting the
+        # fd readable while recv() returns EAGAIN. sock_recv() -- and a naive
+        # add_reader -- re-arm on that and spin one core at 100% CPU.
+        #
+        # A healthy non-blocking socket with no data is NOT reported readable, so
+        # EAGAIN on a fd the selector DID report readable is always a stuck-readable
+        # hangup. Raise on it unconditionally so the future always resolves and the
+        # recv loop reconnects (with backoff) instead of spinning. (The earlier patch
+        # only raised when poll() showed POLLHUP/ERR/NVAL, which missed the logout
+        # NEW_SETTINGS case where the fd is stuck readable without those flags.)
+        loop = asyncio.get_event_loop()
+        fut: asyncio.Future = loop.create_future()
+        fd = self._socket.fileno()
+
+        def _on_readable() -> None:
+            if fut.done():
+                return
+            try:
+                data = self._socket.recv(4096)
+            except InterruptedError:
+                # EINTR: syscall interrupted by a signal. Transient -- let the reader
+                # re-fire and retry recv(); real data is still pending so it won't spin.
+                return
+            except BlockingIOError:
+                # EAGAIN on a readable fd => stuck-readable hangup (see above). poll()
+                # only enriches the diagnostic; we raise either way so the future
+                # always resolves and the reader is removed.
+                poller = select.poll()
+                poller.register(fd, select.POLLHUP | select.POLLERR | select.POLLNVAL)
+                reason = "explicit hangup" if poller.poll(0) else "stuck-readable EAGAIN (adapter reset)"
+                fut.set_exception(BrokenPipeError(f"HCI socket hung up: {reason}"))
+            except Exception as exc:
+                fut.set_exception(exc)
+            else:
+                fut.set_result(data)
+
+        loop.add_reader(fd, _on_readable)
+        try:
+            data = await fut
+        finally:
+            loop.remove_reader(fd)
         return data, len(data) > 0
 
     def _call_done(self, future: asyncio.Future) -> None:

--- a/custom_components/ble_adv/async_socket/__init__.py
+++ b/custom_components/ble_adv/async_socket/__init__.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import os
 import pickle
-import select
 import socket
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Coroutine
@@ -20,6 +19,46 @@ type SocketWaitRecvCallback = Callable[[], Awaitable[tuple[bytes | None, bool]]]
 TUNNEL_SOCKET_FILE_VAR = "TUNNEL_SOCKET_FILE"
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def async_socket_recv(sock: socket.socket, nbbytes: int) -> bytes:
+    """Receive from a non-blocking socket, treating a stuck-readable fd as a hangup.
+
+    Mirrors asyncio loop.sock_recv (optimistic recv, then wait for the selector to
+    report readable) but raises BrokenPipeError when a fd the selector DID report
+    readable still yields EAGAIN. That happens when the controller is reset out from
+    under us by another stack sharing the adapter (host bluetoothd toggling power, or a
+    desktop logout emitting a mgmt NEW_SETTINGS event): the fd stays readable forever
+    while recv() returns EAGAIN. loop.sock_recv() silently re-arms its reader on that
+    EAGAIN and spins one core at 100% CPU; raising lets the recv loop reconnect instead.
+    """
+    try:
+        return sock.recv(nbbytes)
+    except (BlockingIOError, InterruptedError):
+        pass  # no data yet / EINTR: wait for the selector to report readable
+    loop = asyncio.get_running_loop()
+    fut: asyncio.Future = loop.create_future()
+    fd = sock.fileno()
+
+    def _on_readable() -> None:
+        if fut.done():
+            return
+        try:
+            data = sock.recv(nbbytes)
+        except InterruptedError:
+            return  # transient: let the reader re-fire and retry
+        except BlockingIOError:
+            fut.set_exception(BrokenPipeError("HCI socket hung up (stuck-readable EAGAIN; adapter reset)"))
+        except Exception as exc:
+            fut.set_exception(exc)
+        else:
+            fut.set_result(data)
+
+    loop.add_reader(fd, _on_readable)
+    try:
+        return await fut
+    finally:
+        loop.remove_reader(fd)
 
 
 class AsyncSocketBase(ABC):
@@ -152,49 +191,7 @@ class AsyncSocket(AsyncSocketBase):
         """Receive Data from socket."""
         if self._socket is None:
             return None, False
-        # Not loop.sock_recv(): when the controller is reset out from under us by
-        # another stack sharing the adapter (host bluetoothd toggling power, or a
-        # desktop logout emitting mgmt NEW_SETTINGS), the selector keeps reporting the
-        # fd readable while recv() returns EAGAIN. sock_recv() -- and a naive
-        # add_reader -- re-arm on that and spin one core at 100% CPU.
-        #
-        # A healthy non-blocking socket with no data is NOT reported readable, so
-        # EAGAIN on a fd the selector DID report readable is always a stuck-readable
-        # hangup. Raise on it unconditionally so the future always resolves and the
-        # recv loop reconnects (with backoff) instead of spinning. (The earlier patch
-        # only raised when poll() showed POLLHUP/ERR/NVAL, which missed the logout
-        # NEW_SETTINGS case where the fd is stuck readable without those flags.)
-        loop = asyncio.get_event_loop()
-        fut: asyncio.Future = loop.create_future()
-        fd = self._socket.fileno()
-
-        def _on_readable() -> None:
-            if fut.done():
-                return
-            try:
-                data = self._socket.recv(4096)
-            except InterruptedError:
-                # EINTR: syscall interrupted by a signal. Transient -- let the reader
-                # re-fire and retry recv(); real data is still pending so it won't spin.
-                return
-            except BlockingIOError:
-                # EAGAIN on a readable fd => stuck-readable hangup (see above). poll()
-                # only enriches the diagnostic; we raise either way so the future
-                # always resolves and the reader is removed.
-                poller = select.poll()
-                poller.register(fd, select.POLLHUP | select.POLLERR | select.POLLNVAL)
-                reason = "explicit hangup" if poller.poll(0) else "stuck-readable EAGAIN (adapter reset)"
-                fut.set_exception(BrokenPipeError(f"HCI socket hung up: {reason}"))
-            except Exception as exc:
-                fut.set_exception(exc)
-            else:
-                fut.set_result(data)
-
-        loop.add_reader(fd, _on_readable)
-        try:
-            data = await fut
-        finally:
-            loop.remove_reader(fd)
+        data = await async_socket_recv(self._socket, 4096)
         return data, len(data) > 0
 
     def _call_done(self, future: asyncio.Future) -> None:

--- a/tests/async_socket/conftest.py
+++ b/tests/async_socket/conftest.py
@@ -40,7 +40,7 @@ async def socket_mock_inst() -> AsyncGenerator[_SocketMock]:
     with mock.patch("socket.socket", new_callable=_SocketMock) as mock_socket:
         mock_inst = mock_socket.return_value
         mock_inst.init()
-        with mock.patch.object(asyncio.get_event_loop(), "sock_recv", side_effect=mock_inst.sock_recv):
+        with mock.patch("ble_adv.async_socket.async_socket_recv", side_effect=mock_inst.sock_recv):
             yield mock_inst
 
 
@@ -57,7 +57,7 @@ async def btsocket_mock_inst() -> AsyncGenerator[_SocketMock]:
     ):
         mock_inst = mock_socket.return_value
         mock_inst.init()
-        with mock.patch.object(asyncio.get_event_loop(), "sock_recv", side_effect=mock_inst.sock_recv):
+        with mock.patch("ble_adv.async_socket.async_socket_recv", side_effect=mock_inst.sock_recv):
             yield mock_inst
 
 

--- a/tests/async_socket/test_async_socket.py
+++ b/tests/async_socket/test_async_socket.py
@@ -3,10 +3,11 @@
 # ruff: noqa: S101
 import asyncio
 import os
+import socket
 from unittest import mock
 
 import pytest
-from ble_adv.async_socket import TUNNEL_SOCKET_FILE_VAR, AsyncSocket, AsyncTunnelSocket, create_async_socket
+from ble_adv.async_socket import TUNNEL_SOCKET_FILE_VAR, AsyncSocket, AsyncTunnelSocket, async_socket_recv, create_async_socket
 
 from .conftest import _ConMock, _SocketMock
 
@@ -157,3 +158,63 @@ def test_create_async_socket() -> None:
         assert isinstance(create_async_socket(), AsyncSocket)
     with mock.patch.dict(os.environ, {TUNNEL_SOCKET_FILE_VAR: "whatever"}):
         assert isinstance(create_async_socket(), AsyncTunnelSocket)
+
+
+async def test_async_socket_recv_returns_data() -> None:
+    """async_socket_recv returns immediately when data is already available."""
+    sock_a, sock_b = socket.socketpair()
+    sock_a.setblocking(False)
+    try:
+        sock_b.send(b"hello")
+        assert await asyncio.wait_for(async_socket_recv(sock_a, 4096), 1) == b"hello"
+    finally:
+        sock_a.close()
+        sock_b.close()
+
+
+async def test_async_socket_recv_waits_then_returns() -> None:
+    """async_socket_recv suspends until the socket is readable, then returns the data."""
+    sock_a, sock_b = socket.socketpair()
+    sock_a.setblocking(False)
+
+    async def _send_later() -> None:
+        await asyncio.sleep(0.05)
+        sock_b.send(b"later")
+
+    task = asyncio.create_task(_send_later())
+    try:
+        assert await asyncio.wait_for(async_socket_recv(sock_a, 4096), 1) == b"later"
+    finally:
+        await task
+        sock_a.close()
+        sock_b.close()
+
+
+async def test_async_socket_recv_idle_suspends() -> None:
+    """An idle non-blocking socket must suspend, never busy-return EAGAIN (anti reconnect-storm)."""
+    sock_a, sock_b = socket.socketpair()
+    sock_a.setblocking(False)
+    try:
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(async_socket_recv(sock_a, 4096), 0.2)
+    finally:
+        sock_a.close()
+        sock_b.close()
+
+
+async def test_async_socket_recv_stuck_readable_raises() -> None:
+    """A fd the selector reports readable that still yields EAGAIN is a hangup -> BrokenPipeError."""
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, b"x")  # make read_fd readable so the reader callback fires
+    fake = mock.MagicMock()
+    fake.recv.side_effect = BlockingIOError
+    fake.fileno.return_value = read_fd
+    try:
+        with pytest.raises(BrokenPipeError):
+            await asyncio.wait_for(async_socket_recv(fake, 4096), 1)
+        # The fix resolves on the first reader EAGAIN; a re-arm-on-EAGAIN spin
+        # would call recv() thousands of times before the 1s timeout fired.
+        assert fake.recv.call_count < 10
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)


### PR DESCRIPTION
I recently started to control some new ceiling fans in Home Assistant through bluetooth broadcast. Not long after I noticed a home assistant CPU thread pinning at 100%. Finally dug into the root cause to find the fix below.

## Problem

`AsyncSocket._async_recv` reads the raw HCI socket with `loop.sock_recv()`. When the controller is reset out from under the integration by another stack sharing the adapter (host `bluetoothd`, or a desktop logout emitting a mgmt `NEW_SETTINGS` event), the fd is left **stuck-readable**: the selector keeps reporting it readable while `recv()` returns `EAGAIN`. CPython's `sock_recv` re-arms its reader on that `EAGAIN` and never resolves the future — pegging one core at 100% CPU, and the failure never reaches the reconnect path.

This is HCI-specific: on TCP/Unix sockets a hangup surfaces as EOF, not stuck-readable `EAGAIN`. It only reproduces where the adapter is shared/reset by another stack — e.g. a containerized HA on a desktop Linux host whose own stack also drives the controller. On a dedicated adapter it doesn't occur, which is likely why it isn't reproducible everywhere.

## Fix

Add a module-level `async_socket_recv()` that mirrors CPython's `sock_recv` (optimistic `recv()`, reader created only on `EAGAIN`) but **raises `BrokenPipeError` when a fd the selector reported readable still returns `EAGAIN`** — routing into the existing reconnect path instead of spinning. `_async_base_receive` is unchanged: only `BrokenPipeError` exits the loop, so a healthy idle socket still suspends (no busy-loop, no reconnect storm).

Uses the `async_socket_recv` seam from your `dev2` branch so the tests mock it directly (no more patching `loop.sock_recv`).

## Tests

Added regression tests in `tests/async_socket/`:
- stuck-readable hangup → `BrokenPipeError`, with an explicit assertion that `recv()` is **not** called in a busy-loop;
- idle socket → suspends (proves it doesn't reconnect-storm);
- data available, and wait-then-receive.

`pytest` green (578 passed, coverage ≥ 90%), `ruff check` / `ruff format --check` clean, on Python 3.14. Verified live (shared AX210 + host `bluetoothd`): the stuck-readable hangup now self-heals via `BrokenPipeError` → `Manager Refresh` → reconnect instead of pegging a core.

## Scope

This targets the `sock_recv` `EAGAIN`/stuck-readable spin only. It does **not** address advert-processing load after a reconnect on a contended adapter (a separate, deeper issue — I'll open it separately with traces).
