### PR TITLE
Add zhimei_fan_v0_step codec for fans with relative brightness/CT

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The Protocols supported are the ones used by the following Android Phone Apps (a
 * [Vmax smart](https://play.google.com/store/apps/details?id=com.jingyuan.vmax_smart)
 * [Zhi Jia](https://play.google.com/store/apps/details?id=com.cxw.cxwblelight)
 * [Zhi Guang](https://play.google.com/store/apps/details?id=com.cxw.zhiguang)
-* [Zhi Mei Deng Kong](http://mihuan.iotworkshop.com/zhiguang/) (not available on Play Store)
+* [Zhi Mei Deng Kong](http://mihuan.iotworkshop.com/zhiguang/) (not available on Play Store) (see [Stepped dimming](#stepped-dimming) if brightness / colour temperature do not respond)
 * [Mantra Lighting](https://play.google.com/store/apps/details?id=com.newenergy.baolilan)
 * [Smart Light / Argrace Smart](https://apkpure.com/argrace-smart/ai.argrace.oem) (No RGB, Only the control by device, not the Master Control) (not available on Play Store anymore, seems abandoned)
 * [LE Light Pro / 乐智光Pro](https://openapi.lelight.top/dl/cqan) (not available on Play Store)
@@ -40,6 +40,15 @@ The Protocols supported are the ones used by the following Android Phone Apps (a
 * [Smart Elfin](https://play.google.com/store/apps/details?id=com.warpfuture.wfiot.g)
 * [GMIMA](https://www.jasonghost.com/lampSmartGmima/) (not available on Play Store)
 * Other (Legacy), removed app from play store: 'FanLamp', 'ControlSwitch', 'Lamp Smart Pro - Soft Lighting / Smart Lighting'
+
+### Stepped dimming
+Some devices using the Zhi Mei Deng Kong protocol do not implement absolute brightness / colour temperature: they treat those commands as **relative steps** and ignore the level that is sent. On such a device the brightness and colour temperature sliders appear to do nothing, while On/Off, fan speed and direction all work normally.
+
+For those, select the **Zhi Mei Deng Kong (Fan, stepped dimming)** Phone App: it sends a burst of single steps to reach the requested level instead of one absolute command.
+
+If your device already responds correctly to the brightness slider, keep the standard **Zhi Mei Deng Kong (Fan)** Phone App. The two are separate protocols and the standard one is unchanged.
+
+Note that the integration then has to track the current level itself, so it may drift if the device is also controlled by a remote that the integration cannot listen to (an RF or IR remote, for instance). Setting the slider to 0% or 100% resynchronizes it.
 
 If the protocols of your application are not supported yet you can request for their support [here](https://github.com/NicoIIT/ha-ble-adv/issues/new?template=new_app.yml).
 

--- a/custom_components/ble_adv/codecs/__init__.py
+++ b/custom_components/ble_adv/codecs/__init__.py
@@ -20,6 +20,7 @@ _PHONE_APPS_BASE = {
     "Zhi Jia": ["zhijia_v2", "zhijia_v1", "zhijia_v0"],
     "Zhi Guang": ["zhiguang_v2", "zhiguang_v1", "zhiguang_v0"],
     "Zhi Mei Deng Kong (Fan)": ["zhimei_fan_v1", "zhimei_fan_v0"],
+    "Zhi Mei Deng Kong (Fan, stepped dimming)": ["zhimei_fan_v0_step"],
     "Zhi Mei Deng Kong (Light only)": ["zhimei_v2", "zhimei_v1"],
     "Smart Light": ["agarce_v4", "agarce_v3"],
     "LE Light": ["lelight"],

--- a/custom_components/ble_adv/codecs/zhimei.py
+++ b/custom_components/ble_adv/codecs/zhimei.py
@@ -30,6 +30,7 @@ from .const import (
     ATTR_WARM,
 )
 from .models import (
+    BleAdvAdvertisement,
     BleAdvCodec,
     BleAdvConfig,
     BleAdvEncCmd,
@@ -82,6 +83,58 @@ class ZhimeiEncoderV0(BleAdvCodec):
         """Convert an encoder command and a config into a readable buffer."""
         uid = conf.id.to_bytes(2, "little")
         return bytes([conf.index, conf.tx_count, *uid, enc_cmd.cmd, enc_cmd.arg0, enc_cmd.arg1, enc_cmd.arg2])
+
+
+class ZhimeiFanStepEncoderV0(ZhimeiEncoderV0):
+    """Zhi Mei V0 fan encoder where 0xB5 / 0xB7 are relative STEP commands.
+
+    Some fan lamps (e.g. TCL JJ-FS2.4G+LED) do not implement absolute brightness /
+    colour temp: the level carried in arg1/arg2 is ignored - it is only what the phone
+    app reports as its own target - and each received packet moves the level by one
+    step (~2%), arg0 giving the direction (1 = up, 2 = down). Such devices also
+    de-duplicate packets sharing a tx_count, so a burst is only effective if tx
+    increments on every step.
+
+    This is a separate codec: devices that DO honour absolute levels must keep using
+    'zhimei_fan_v0'. See https://github.com/NicoIIT/ha-ble-adv/issues/192.
+    """
+
+    _STEP: float = 0.02
+    _RAIL_STEPS: int = 60
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._levels: dict[tuple[int, int, int], float] = {}
+
+    def _burst(self, enc_cmd: BleAdvEncCmd, conf: BleAdvConfig, direction: int, count: int, level: float) -> list[BleAdvAdvertisement]:
+        """Emit 'count' single steps in 'direction', each with its own tx_count."""
+        step = BleAdvEncCmd(enc_cmd.cmd)
+        step.param = enc_cmd.param
+        step.arg0 = direction
+        raw = min(1000, max(0, round(level * 1000.0)))
+        step.arg1, step.arg2 = raw >> 8, raw & 0xFF
+        advs: list[BleAdvAdvertisement] = []
+        for _ in range(count):
+            advs += super().encode_advs(step, conf)
+        return advs
+
+    def encode_advs(self, enc_cmd: BleAdvEncCmd, conf: BleAdvConfig) -> list[BleAdvAdvertisement]:
+        """Expand an absolute level command into a burst of relative steps."""
+        if enc_cmd.cmd not in (0xB5, 0xB7):
+            return super().encode_advs(enc_cmd, conf)
+        key = (conf.id, conf.index, enc_cmd.cmd)
+        target = min(1.0, max(0.0, ((enc_cmd.arg1 << 8) + enc_cmd.arg2) / 1000.0))
+        current = self._levels.get(key)
+        advs: list[BleAdvAdvertisement] = []
+        if current is None:
+            # Level unknown (restart, or a remote we cannot observe moved it): peg to the
+            # bottom rail first so the step count below is meaningful.
+            advs += self._burst(enc_cmd, conf, 2, self._RAIL_STEPS, 0.0)
+            current = 0.0
+        if (count := round(abs(target - current) / self._STEP)) > 0:
+            advs += self._burst(enc_cmd, conf, 1 if target > current else 2, count, target)
+        self._levels[key] = target
+        return advs
 
 
 class ZhimeiEncoderV1(BleAdvCodec):
@@ -314,6 +367,8 @@ TRANS_FAN_V1 = [
 CODECS = [
     # Zhi Mei standard Android App
     ZhimeiEncoderV0().id("zhimei_fan_v0").header([0x55]).ble(0x19, 0x03).add_translators(TRANS_FAN_COMMON).add_rev_only_trans(TRANS_REMOTE),
+    # Same protocol, but for devices on which 0xB5 / 0xB7 are relative steps (issue #192)
+    ZhimeiFanStepEncoderV0().fid("zhimei_fan_v0_step", "zhimei_fan_v0").header([0x55]).ble(0x19, 0x03).add_translators(TRANS_FAN_COMMON).add_rev_only_trans(TRANS_REMOTE),
     ZhimeiEncoderV1().id("zhimei_fan_v1").header([0x48, 0x46, 0x4B, 0x4A]).ble(0x1A, 0x03).add_translators(TRANS_FAN_V1).add_rev_only_trans(TRANS_REMOTE),
     ZhimeiEncoderV1().id("zhimei_v1").header([0x48, 0x46, 0x4B, 0x4A]).ble(0x1A, 0x03).add_translators(TRANS_V1),
     ZhimeiEncoderV2().id("zhimei_v2").header([0xF9, 0x08, 0x49]).ble(0x1A, 0x03).prefix([0x33, 0xAA, 0x55]).add_translators(TRANS_V2),

--- a/tests/codecs/test_zhimei.py
+++ b/tests/codecs/test_zhimei.py
@@ -1,14 +1,15 @@
 """Zhi Mei pro Unit Tests."""
 
 import pytest
+from ble_adv.codecs.const import ATTR_BR, ATTR_CT_REV, ATTR_ON
+from ble_adv.codecs.models import BleAdvConfig, BleAdvEntAttr
 
-from . import _TestEncoderBase, _TestEncoderFull
+from . import CODECS, _TestEncoderBase, _TestEncoderFull
 
 
 @pytest.mark.parametrize(
     _TestEncoderBase.PARAM_NAMES,
     [
-        ("zhimei_fan_v0", 0x03, "55.02.01.02.C0.B4.AA.66.55.33"),
         ("zhimei_v2", 0x03, "F9.08.49.B2.CE.2C.81.3B.6B.90.08.CE.EF.3D.6F.C8.10.11.12.13.14.15.16.17.18.19"),
         ("zhimei_v1b", 0xFF, "58.55.18.48.46.4B.4A.1C.AB.1F.B8.0E.B7.E1.7D.98.82.31.A5.7E.7E.DB.68.10.11.12.13.14.15"),
         ("zhimei_fan_vr0", 0x00, "55.FF.63.01.6A.10.00.00.00.32"),
@@ -26,6 +27,10 @@ class TestEncoderZhimei(_TestEncoderBase):
     [
         ("zhimei_fan_v1", 0x03, "48.46.4B.4A.8F.D3.A4.49.9B.44.6E.EA.23.F5.B6.36.0F.ED.8F.DE.10.11.12.13.14.15"),
         ("zhimei_v1", 0x03, "48.46.4B.4A.1C.AB.1F.B8.0E.B7.E1.7D.98.82.31.A5.7E.7E.DB.68.10.11.12.13.14.15"),
+        # zhimei_fan_v0 and zhimei_fan_v0_step share the V0 encoder, header and BLE type,
+        # so both decode any v0-format packet. The dupe is expected.
+        ("zhimei_fan_v0", 0x03, "55.02.01.02.C0.B4.AA.66.55.33"),
+        ("zhimei_fan_v0_step", 0x03, "55.02.01.02.C0.B4.AA.66.55.33"),
         ("zhimei_fan_v1", 0x03, "48.46.4B.4A.51.20.E8.30.90.E0.35.22.5D.CE.A2.58.CD.03.82.75.10.11.12.13.14.15"),
     ],
 )
@@ -881,3 +886,72 @@ class TestEncoderZhimeiFanRemoteNoDirect(_TestEncoderFull):
 )
 class TestEncoderZhimeiFanRemote(_TestEncoderFull):
     """Zhi Mei Fan Encoder / Decoder Fan Remote tests."""
+
+
+class TestZhimeiFanV0Step:
+    """zhimei_fan_v0_step: 0xB5 / 0xB7 expand into bursts of relative steps."""
+
+    _STEP = 0.02
+    _RAIL = 60
+
+    def _advs(self, target: float, attr: str, conf: BleAdvConfig) -> list:
+        codec = CODECS["zhimei_fan_v0_step"]
+        ent = BleAdvEntAttr([attr], {"sub_type": "cww", attr: target, ATTR_ON: True}, "light", 0)
+        advs = []
+        for enc_cmd in codec.ent_to_enc(ent):
+            advs += codec.encode_advs(enc_cmd, conf)
+        return advs
+
+    def test_absolute_codec_untouched(self) -> None:
+        """The pre-existing codec must keep emitting a single absolute command."""
+        conf = BleAdvConfig(0xC002, 2)
+        codec = CODECS["zhimei_fan_v0"]
+        ent = BleAdvEntAttr([ATTR_BR], {"sub_type": "cww", ATTR_BR: 0.5, ATTR_ON: True}, "light", 0)
+        advs = []
+        for enc_cmd in codec.ent_to_enc(ent):
+            advs += codec.encode_advs(enc_cmd, conf)
+        assert len(advs) == 1
+
+    def test_cold_start_pegs_to_rail_then_steps(self) -> None:
+        """First command with an unknown level rails down, then steps to target."""
+        conf = BleAdvConfig(0xC002, 2)
+        advs = self._advs(0.5, ATTR_BR, conf)
+        assert len(advs) == self._RAIL + round(0.5 / self._STEP)
+
+    def test_delta_and_direction(self) -> None:
+        """Subsequent commands emit |delta| steps in the right direction."""
+        conf = BleAdvConfig(0xC002, 2)
+        self._advs(0.5, ATTR_BR, conf)  # establish a known level
+        up = self._advs(1.0, ATTR_BR, conf)
+        assert len(up) == round(0.5 / self._STEP)
+        assert {a.raw[6] for a in up} == {1}
+        down = self._advs(0.2, ATTR_BR, conf)
+        assert len(down) == round(0.8 / self._STEP)
+        assert {a.raw[6] for a in down} == {2}
+
+    def test_no_change_emits_nothing(self) -> None:
+        """Re-sending the current level emits no packets."""
+        conf = BleAdvConfig(0xC002, 2)
+        self._advs(0.4, ATTR_BR, conf)
+        assert self._advs(0.4, ATTR_BR, conf) == []
+
+    def test_tx_increments_across_burst(self) -> None:
+        """Every packet in a burst carries a distinct tx_count, else the device de-dupes."""
+        conf = BleAdvConfig(0xC002, 2)
+        codec = CODECS["zhimei_fan_v0_step"]
+        saved = codec._tx_step  # noqa: SLF001
+        codec._tx_step = 1  # noqa: SLF001  - the shared harness pins it to 0 for determinism
+        try:
+            self._advs(0.0, ATTR_BR, conf)
+            advs = self._advs(0.6, ATTR_BR, conf)
+        finally:
+            codec._tx_step = saved  # noqa: SLF001
+        txs = [a.raw[2] for a in advs]
+        assert len(set(txs)) == len(txs)
+
+    def test_ct_uses_same_expansion(self) -> None:
+        """Colour temp (0xB7) behaves like brightness."""
+        conf = BleAdvConfig(0xC002, 2)
+        self._advs(0.0, ATTR_CT_REV, conf)
+        advs = self._advs(0.5, ATTR_CT_REV, conf)
+        assert {a.raw[5] for a in advs} == {0xB7}


### PR DESCRIPTION
## Summary

Adds `zhimei_fan_v0_step`, a codec for Zhi Mei V0 fan lamps where brightness (`0xB5`) and colour temperature (`0xB7`) are **relative step** commands rather than absolute set. Fixes #192.

On these devices `arg0` is the direction (`1` = up, `2` = down), the level in `arg1`/`arg2` is ignored, and each packet moves the level ~2%. They also de-duplicate packets sharing a `tx_count`.

The existing codec sends one command repeated with an identical `tx_count`, which such a device collapses to a single ~2% step — so brightness and colour temperature appear dead while on/off, speed and direction work.

## Approach

`ZhimeiFanStepEncoderV0.encode_advs()` expands an absolute level change into a burst of single steps, each with its own `tx_count`, returned as one list so it lands in a single `BleAdvQueueItem` — otherwise `enqueue()`'s `key` eviction would collapse it. When the current level is unknown it pegs to the bottom rail first so the step count is meaningful.

**`zhimei_fan_v0` is deliberately untouched.** I only have one device model, so I can't tell whether other Zhi Mei devices honour absolute levels. `test_absolute_codec_untouched` enforces it still emits exactly one advertisement. It shares the `zhimei_fan_v0` `match_id` following the `zhimei_fan_v1b` precedent, so `zhimei_fan_vr0` covers it too.

## Testing

`lint` and `test` pass in the devcontainer. Six new tests cover cold-start rail calibration, delta and direction, no-op suppression, unique `tx` per burst, and CT. Validated on real hardware (TCL JJ-FS2.4G+LED) via an ESPHome `ble_adv_proxy`.

## Additional notes

- `_STEP = 0.02` is measured from one device model.
- First change after a restart visibly dips to minimum. Deliberate; the alternative is an inaccurate first move.
- The level drifts if the device is also driven by a controller the integration can't observe. Documented, resynchronised by setting 0% or 100%.
