### PR TITLE
Implement multi-language preset translations for fan

### DIFF
--- a/custom_components/ble_adv/fan.py
+++ b/custom_components/ble_adv/fan.py
@@ -42,8 +42,68 @@ from .const import (
 )
 from .device import ATTR_IS_ON, BleAdvDevice, BleAdvEntAttr, BleAdvEntity, BleAdvStateAttribute
 
+# Multi-language preset mappings for all integration locales
+PRESET_TRANSLATIONS: dict[str, dict[str, str]] = {
+    "en": {
+        "sleep": "Sleep Mode",
+        "breeze": "Breeze Mode",
+    },
+    "es": {
+        "sleep": "Modo Sueño",
+        "breeze": "Modo Brisa",
+    },
+    "fr": {
+        "sleep": "Mode Nuit",
+        "breeze": "Mode Brise",
+    },
+    "ru": {
+        "sleep": "Спящий режим",
+        "breeze": "Режим бриза",
+    },
+    "cs": {
+        "sleep": "Režim spánku",
+        "breeze": "Režim vánku",
+    },
+    "sk": {
+        "sleep": "Režim spánku",
+        "breeze": "Režim vánku",
+    },
+    "hu": {
+        "sleep": "Alvó mód",
+        "breeze": "Szellő mód",
+    },
+    "zh": {
+        "sleep": "睡眠模式",
+        "breeze": "自然风模式",
+    },
+    "zh-Hans": {
+        "sleep": "睡眠模式",
+        "breeze": "自然风模式",
+    },
+}
 
-def create_entity(options: dict[str, Any], device: BleAdvDevice, index: int) -> BleAdvFan:
+
+def _get_preset_mappings(language: str) -> tuple[dict[str, str], dict[str, str]]:
+    """Get display and canonical mappings for a language."""
+    display_map = (
+        PRESET_TRANSLATIONS.get(language)
+        or PRESET_TRANSLATIONS.get(language.split("-")[0])
+        or PRESET_TRANSLATIONS.get("es" if language.startswith("es") else "en", {})
+    )
+    # Bidirectional canonical map covering all supported languages
+    canonical_map = {}
+    for lang_dict in PRESET_TRANSLATIONS.values():
+        for k, v in lang_dict.items():
+            canonical_map[v] = k
+            canonical_map[k] = k
+    canonical_map["Modo Dormir"] = "sleep"
+    canonical_map["Modo Sueño"] = "sleep"
+    canonical_map["Modo Brisa"] = "breeze"
+
+    return display_map, canonical_map
+
+
+def create_entity(options: dict[str, Any], device: BleAdvDevice, index: int, language: str = "en") -> BleAdvFan:
     """Create a Fan Entity from the entry."""
     features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF | FanEntityFeature.SET_SPEED
     presets = options.get(CONF_PRESETS, [])
@@ -54,7 +114,7 @@ def create_entity(options: dict[str, Any], device: BleAdvDevice, index: int) -> 
     if len(presets) > 0:
         features |= FanEntityFeature.PRESET_MODE
 
-    fan = BleAdvFan(device, index, int(options[CONF_TYPE][:-5]), features, presets)
+    fan = BleAdvFan(device, index, int(options[CONF_TYPE][:-5]), features, presets, language)
     fan.refresh_dir_on_start = options.get(CONF_REFRESH_DIR_ON_START, False)
     fan.refresh_osc_on_start = options.get(CONF_REFRESH_OSC_ON_START, False)
     fan.set_forced_cmds(options.get(CONF_FORCED_CMDS, []))
@@ -65,6 +125,124 @@ def create_entity(options: dict[str, Any], device: BleAdvDevice, index: int) -> 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Entry setup."""
     device: BleAdvDevice = hass.data[DOMAIN][entry.entry_id]
+    language = hass.config.language or "en"
+    entities = [
+        create_entity(options, device, i, language)
+        for i, options in enumerate(entry.data[CONF_FANS])
+        if CONF_TYPE in options
+    ]
+    async_add_entities(entities, True)
+
+
+class BleAdvFan(BleAdvEntity, FanEntity):
+    """Ble Adv Fan Entity."""
+
+    _state_attributes = frozenset(
+        [
+            BleAdvStateAttribute(ATTR_IS_ON, False, [ATTR_ON]),
+            BleAdvStateAttribute(ATTR_PERCENTAGE, 100, [ATTR_SPEED], [ATTR_PRESET_MODE]),
+            BleAdvStateAttribute(ATTR_DIRECTION, DIRECTION_FORWARD, [ATTR_DIR]),
+            BleAdvStateAttribute(ATTR_OSCILLATING, False, [ATTR_OSC]),
+            BleAdvStateAttribute(ATTR_PRESET_MODE, None, [ATTR_PRESET]),
+        ]
+    )
+    _attr_direction = None
+
+    refresh_dir_on_start: bool = False
+    refresh_osc_on_start: bool = False
+
+    def __init__(
+        self,
+        device: BleAdvDevice,
+        index: int,
+        speed_count: int,
+        features: FanEntityFeature,
+        presets: list[str],
+        language: str = "en",
+    ) -> None:
+        super().__init__(FAN_TYPE, None, device, index)
+        self._attr_supported_features: FanEntityFeature = features
+        self._attr_speed_count: int = speed_count
+        self._display_map, self._canonical_map = _get_preset_mappings(language)
+        self._attr_preset_modes = [self._display_map.get(p, p) for p in presets]
+
+    @property
+    def current_direction(self) -> str | None:
+        """Return the current direction of the fan."""
+        return self._attr_direction
+
+    @property
+    def percentage(self) -> int | None:
+        """Return the percentage of the fan."""
+        return self._attr_percentage if self._attr_preset_mode is None else 0
+
+    def get_attrs(self) -> dict[str, Any]:
+        """Get the attrs."""
+        eff_percentage = self._attr_percentage if self._attr_percentage is not None else 0
+        return {
+            **super().get_attrs(),
+            ATTR_SPEED_COUNT: self._attr_speed_count,
+            ATTR_DIR: self._attr_direction == DIRECTION_FORWARD,
+            ATTR_OSC: self._attr_oscillating,
+            ATTR_PRESET: self._canonical_map.get(self._attr_preset_mode, self._attr_preset_mode),
+            ATTR_SPEED: ceil(percentage_to_ranged_value((1, self._attr_speed_count), eff_percentage)),
+        }
+
+    def forced_changed_attr_on_start(self) -> list[str]:
+        """List Forced changed attributes on start."""
+        forced_attrs = []
+        if self._attr_supported_features & FanEntityFeature.PRESET_MODE:
+            forced_attrs.append(ATTR_PRESET)
+        if self.refresh_osc_on_start and self._attr_supported_features & FanEntityFeature.OSCILLATE:
+            forced_attrs.append(ATTR_OSC)
+        if self.refresh_dir_on_start and self._attr_supported_features & FanEntityFeature.DIRECTION:
+            forced_attrs.append(ATTR_DIR)
+        return forced_attrs
+
+    def apply_attrs(self, ent_attr: BleAdvEntAttr) -> None:
+        """Apply the attributes to this Entity."""
+        super().apply_attrs(ent_attr)
+        if ATTR_DIR in ent_attr.chg_attrs:
+            new_val = self.change_bool(self._attr_direction == DIRECTION_FORWARD, ent_attr.attrs[ATTR_DIR])
+            self._attr_direction = DIRECTION_FORWARD if new_val else DIRECTION_REVERSE
+        if ATTR_OSC in ent_attr.chg_attrs:
+            self._attr_oscillating = self.change_bool(self._attr_oscillating, ent_attr.attrs[ATTR_OSC])
+        if ATTR_SPEED in ent_attr.chg_attrs:
+            self._attr_preset_mode = None
+            speed_count = ent_attr.attrs.get(ATTR_SPEED_COUNT, self._attr_speed_count)
+            self._attr_percentage = ranged_value_to_percentage((1, speed_count), ent_attr.attrs[ATTR_SPEED])
+        if ATTR_PRESET in ent_attr.chg_attrs:
+            raw_preset = ent_attr.attrs[ATTR_PRESET]
+            self._attr_preset_mode = self._display_map.get(raw_preset, raw_preset) if raw_preset is not None else None
+
+    async def async_turn_on(self, percentage: int | None = None, preset_mode: str | None = None, **kwargs) -> None:  # noqa: ANN003
+        """Turn Entity on / set percentage / preset mode. Percentage is taking precedence over preset_mode."""
+        if (percent := kwargs.get(ATTR_PERCENTAGE, percentage)) is not None:
+            await self.async_set_percentage(percent)
+        elif (preset := kwargs.get(ATTR_PRESET_MODE, preset_mode)) is not None:
+            await self.async_set_preset_mode(preset)
+        else:
+            await self._handle_state_change({ATTR_IS_ON: True})
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed percentage of the fan."""
+        if percentage == 0:
+            await self._handle_state_change({ATTR_IS_ON: False})
+        else:
+            await self._handle_state_change({ATTR_IS_ON: True, ATTR_PERCENTAGE: percentage})
+
+    async def async_set_direction(self, direction: str) -> None:
+        """Set the direction of the fan."""
+        await self._handle_state_change({ATTR_IS_ON: True, ATTR_DIRECTION: direction})
+
+    async def async_oscillate(self, oscillating: bool) -> None:
+        """Oscillate the fan."""
+        await self._handle_state_change({ATTR_IS_ON: True, ATTR_OSCILLATING: oscillating})
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode of the fan."""
+        canonical_preset = self._canonical_map.get(preset_mode, preset_mode)
+        await self._handle_state_change({ATTR_IS_ON: True, ATTR_PRESET_MODE: canonical_preset})    device: BleAdvDevice = hass.data[DOMAIN][entry.entry_id]
     entities = [create_entity(options, device, i) for i, options in enumerate(entry.data[CONF_FANS]) if CONF_TYPE in options]
     async_add_entities(entities, True)
 

--- a/custom_components/ble_adv/fan.py
+++ b/custom_components/ble_adv/fan.py
@@ -88,7 +88,7 @@ def _get_preset_mappings(language: str) -> tuple[dict[str, str], dict[str, str]]
     display_map = (
         PRESET_TRANSLATIONS.get(language)
         or PRESET_TRANSLATIONS.get(language.split("-")[0])
-        or PRESET_TRANSLATIONS.get("es" if language.startswith("es") else "en", {})
+        or PRESET_TRANSLATIONS.get("en", {})
     )
     # Bidirectional canonical map covering all supported languages
     canonical_map = {}
@@ -242,115 +242,4 @@ class BleAdvFan(BleAdvEntity, FanEntity):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         canonical_preset = self._canonical_map.get(preset_mode, preset_mode)
-        await self._handle_state_change({ATTR_IS_ON: True, ATTR_PRESET_MODE: canonical_preset})    device: BleAdvDevice = hass.data[DOMAIN][entry.entry_id]
-    entities = [create_entity(options, device, i) for i, options in enumerate(entry.data[CONF_FANS]) if CONF_TYPE in options]
-    async_add_entities(entities, True)
-
-
-class BleAdvFan(BleAdvEntity, FanEntity):
-    """Ble Adv Fan Entity."""
-
-    _state_attributes = frozenset(
-        [
-            BleAdvStateAttribute(ATTR_IS_ON, False, [ATTR_ON]),
-            BleAdvStateAttribute(ATTR_PERCENTAGE, 100, [ATTR_SPEED], [ATTR_PRESET_MODE]),
-            BleAdvStateAttribute(ATTR_DIRECTION, DIRECTION_FORWARD, [ATTR_DIR]),
-            BleAdvStateAttribute(ATTR_OSCILLATING, False, [ATTR_OSC]),
-            BleAdvStateAttribute(ATTR_PRESET_MODE, None, [ATTR_PRESET]),
-        ]
-    )
-    _attr_direction = None
-
-    refresh_dir_on_start: bool = False
-    refresh_osc_on_start: bool = False
-
-    def __init__(
-        self,
-        device: BleAdvDevice,
-        index: int,
-        speed_count: int,
-        features: FanEntityFeature,
-        presets: list[str],
-    ) -> None:
-        super().__init__(FAN_TYPE, None, device, index)
-        self._attr_supported_features: FanEntityFeature = features
-        self._attr_speed_count: int = speed_count
-        self._attr_preset_modes = presets
-
-    # redefining 'current_direction' as the attribute name is messy, and not the one defined in the last_state
-    @property
-    def current_direction(self) -> str | None:
-        """Return the current direction of the fan."""
-        return self._attr_direction
-
-    # redefining 'percentage' in order to consider it 0 when a preset mode is setup
-    @property
-    def percentage(self) -> int | None:
-        """Return the percentage of the fan."""
-        return self._attr_percentage if self._attr_preset_mode is None else 0
-
-    def get_attrs(self) -> dict[str, Any]:
-        """Get the attrs."""
-        eff_percentage = self._attr_percentage if self._attr_percentage is not None else 0
-        return {
-            **super().get_attrs(),
-            ATTR_SPEED_COUNT: self._attr_speed_count,
-            ATTR_DIR: self._attr_direction == DIRECTION_FORWARD,
-            ATTR_OSC: self._attr_oscillating,
-            ATTR_PRESET: self._attr_preset_mode,
-            ATTR_SPEED: ceil(percentage_to_ranged_value((1, self._attr_speed_count), eff_percentage)),
-        }
-
-    def forced_changed_attr_on_start(self) -> list[str]:
-        """List Forced changed attributes on start."""
-        forced_attrs = []
-        if self._attr_supported_features & FanEntityFeature.PRESET_MODE:
-            forced_attrs.append(ATTR_PRESET)
-        if self.refresh_osc_on_start and self._attr_supported_features & FanEntityFeature.OSCILLATE:
-            forced_attrs.append(ATTR_OSC)
-        if self.refresh_dir_on_start and self._attr_supported_features & FanEntityFeature.DIRECTION:
-            forced_attrs.append(ATTR_DIR)
-        return forced_attrs
-
-    def apply_attrs(self, ent_attr: BleAdvEntAttr) -> None:
-        """Apply the attributes to this Entity."""
-        super().apply_attrs(ent_attr)
-        if ATTR_DIR in ent_attr.chg_attrs:
-            new_val = self.change_bool(self._attr_direction == DIRECTION_FORWARD, ent_attr.attrs[ATTR_DIR])
-            self._attr_direction = DIRECTION_FORWARD if new_val else DIRECTION_REVERSE
-        if ATTR_OSC in ent_attr.chg_attrs:
-            self._attr_oscillating = self.change_bool(self._attr_oscillating, ent_attr.attrs[ATTR_OSC])
-        if ATTR_SPEED in ent_attr.chg_attrs:
-            self._attr_preset_mode = None
-            speed_count = ent_attr.attrs.get(ATTR_SPEED_COUNT, self._attr_speed_count)
-            self._attr_percentage = ranged_value_to_percentage((1, speed_count), ent_attr.attrs[ATTR_SPEED])
-        if ATTR_PRESET in ent_attr.chg_attrs:
-            self._attr_preset_mode = ent_attr.attrs[ATTR_PRESET]
-
-    async def async_turn_on(self, percentage: int | None = None, preset_mode: str | None = None, **kwargs) -> None:  # noqa: ANN003
-        """Turn Entity on / set percentage / preset mode. Percentage is taking precedence over preset_mode."""
-        if (percent := kwargs.get(ATTR_PERCENTAGE, percentage)) is not None:
-            await self.async_set_percentage(percent)
-        elif (preset := kwargs.get(ATTR_PRESET_MODE, preset_mode)) is not None:
-            await self.async_set_preset_mode(preset)
-        else:
-            await self._handle_state_change({ATTR_IS_ON: True})
-
-    async def async_set_percentage(self, percentage: int) -> None:
-        """Set the speed percentage of the fan."""
-        if percentage == 0:
-            await self._handle_state_change({ATTR_IS_ON: False})
-        else:
-            await self._handle_state_change({ATTR_IS_ON: True, ATTR_PERCENTAGE: percentage})
-
-    async def async_set_direction(self, direction: str) -> None:
-        """Set the direction of the fan."""
-        await self._handle_state_change({ATTR_IS_ON: True, ATTR_DIRECTION: direction})
-
-    async def async_oscillate(self, oscillating: bool) -> None:
-        """Oscillate the fan."""
-        await self._handle_state_change({ATTR_IS_ON: True, ATTR_OSCILLATING: oscillating})
-
-    async def async_set_preset_mode(self, preset_mode: str) -> None:
-        """Set the preset mode of the fan."""
-        await self._handle_state_change({ATTR_IS_ON: True, ATTR_PRESET_MODE: preset_mode})
+        await self._handle_state_change({ATTR_IS_ON: True, ATTR_PRESET_MODE: canonical_preset})

--- a/custom_components/ble_adv/fan.py
+++ b/custom_components/ble_adv/fan.py
@@ -87,7 +87,7 @@ def _get_preset_mappings(language: str) -> tuple[dict[str, str], dict[str, str]]
     """Get display and canonical mappings for a language."""
     display_map = (
         PRESET_TRANSLATIONS.get(language)
-        or PRESET_TRANSLATIONS.get(language.split("-")[0])
+        or PRESET_TRANSLATIONS.get(language.split("-", maxsplit=1)[0])
         or PRESET_TRANSLATIONS.get("en", {})
     )
     # Bidirectional canonical map covering all supported languages

--- a/custom_components/ble_adv/fan.py
+++ b/custom_components/ble_adv/fan.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from math import ceil
+from pathlib import Path
 from typing import Any
 
 from homeassistant.components.fan import (
@@ -42,62 +44,26 @@ from .const import (
 )
 from .device import ATTR_IS_ON, BleAdvDevice, BleAdvEntAttr, BleAdvEntity, BleAdvStateAttribute
 
-# Multi-language preset mappings for all integration locales
-PRESET_TRANSLATIONS: dict[str, dict[str, str]] = {
-    "en": {
-        "sleep": "Sleep Mode",
-        "breeze": "Breeze Mode",
-    },
-    "es": {
-        "sleep": "Modo Sueño",
-        "breeze": "Modo Brisa",
-    },
-    "fr": {
-        "sleep": "Mode Nuit",
-        "breeze": "Mode Brise",
-    },
-    "ru": {
-        "sleep": "Спящий режим",
-        "breeze": "Режим бриза",
-    },
-    "cs": {
-        "sleep": "Režim spánku",
-        "breeze": "Režim vánku",
-    },
-    "sk": {
-        "sleep": "Režim spánku",
-        "breeze": "Režim vánku",
-    },
-    "hu": {
-        "sleep": "Alvó mód",
-        "breeze": "Szellő mód",
-    },
-    "zh": {
-        "sleep": "睡眠模式",
-        "breeze": "自然风模式",
-    },
-    "zh-Hans": {
-        "sleep": "睡眠模式",
-        "breeze": "自然风模式",
-    },
-}
+TRANSLATIONS_PATH = Path(__file__).parent / "translations"
 
 
-def _get_preset_mappings(language: str) -> tuple[dict[str, str], dict[str, str]]:
-    """Get display and canonical mappings for a language."""
-    display_map = (
-        PRESET_TRANSLATIONS.get(language) or PRESET_TRANSLATIONS.get(language.split("-", maxsplit=1)[0]) or PRESET_TRANSLATIONS.get("en", {})
-    )
-    # Bidirectional canonical map covering all supported languages
-    canonical_map = {}
-    for lang_dict in PRESET_TRANSLATIONS.values():
-        for k, v in lang_dict.items():
-            canonical_map[v] = k
-            canonical_map[k] = k
-    canonical_map["Modo Dormir"] = "sleep"
-    canonical_map["Modo Sueño"] = "sleep"
-    canonical_map["Modo Brisa"] = "breeze"
+def _load_preset_mappings(language: str) -> tuple[dict[str, str], dict[str, str]]:
+    """Load preset mappings dynamically from translations directory."""
+    display_map: dict[str, str] = {}
+    for lang in (language, language.split("-", maxsplit=1)[0], "en"):
+        lang_file = TRANSLATIONS_PATH / f"{lang}.json"
+        if lang_file.is_file():
+            try:
+                with lang_file.open(encoding="utf-8") as f:
+                    data = json.load(f)
+                display_map = data.get("selector", {}).get("presets", {}).get("options", {})
+                if display_map:
+                    break
+            except Exception:  # noqa: BLE001
+                pass
 
+    canonical_map = {v: k for k, v in display_map.items()}
+    canonical_map.update({k: k for k in display_map})
     return display_map, canonical_map
 
 
@@ -159,7 +125,7 @@ class BleAdvFan(BleAdvEntity, FanEntity):
         super().__init__(FAN_TYPE, None, device, index)
         self._attr_supported_features: FanEntityFeature = features
         self._attr_speed_count: int = speed_count
-        self._display_map, self._canonical_map = _get_preset_mappings(language)
+        self._display_map, self._canonical_map = _load_preset_mappings(language)
         self._attr_preset_modes = [self._display_map.get(p, p) for p in presets]
 
     @property

--- a/custom_components/ble_adv/fan.py
+++ b/custom_components/ble_adv/fan.py
@@ -86,9 +86,7 @@ PRESET_TRANSLATIONS: dict[str, dict[str, str]] = {
 def _get_preset_mappings(language: str) -> tuple[dict[str, str], dict[str, str]]:
     """Get display and canonical mappings for a language."""
     display_map = (
-        PRESET_TRANSLATIONS.get(language)
-        or PRESET_TRANSLATIONS.get(language.split("-", maxsplit=1)[0])
-        or PRESET_TRANSLATIONS.get("en", {})
+        PRESET_TRANSLATIONS.get(language) or PRESET_TRANSLATIONS.get(language.split("-", maxsplit=1)[0]) or PRESET_TRANSLATIONS.get("en", {})
     )
     # Bidirectional canonical map covering all supported languages
     canonical_map = {}
@@ -126,11 +124,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     """Entry setup."""
     device: BleAdvDevice = hass.data[DOMAIN][entry.entry_id]
     language = hass.config.language or "en"
-    entities = [
-        create_entity(options, device, i, language)
-        for i, options in enumerate(entry.data[CONF_FANS])
-        if CONF_TYPE in options
-    ]
+    entities = [create_entity(options, device, i, language) for i, options in enumerate(entry.data[CONF_FANS]) if CONF_TYPE in options]
     async_add_entities(entities, True)
 
 

--- a/custom_components/ble_adv/fan.py
+++ b/custom_components/ble_adv/fan.py
@@ -131,6 +131,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 class BleAdvFan(BleAdvEntity, FanEntity):
     """Ble Adv Fan Entity."""
 
+    _attr_icon = "mdi:ceiling-fan"
+
     _state_attributes = frozenset(
         [
             BleAdvStateAttribute(ATTR_IS_ON, False, [ATTR_ON]),

--- a/custom_components/ble_adv/fan.py
+++ b/custom_components/ble_adv/fan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 from math import ceil
 from pathlib import Path
@@ -53,14 +54,12 @@ def _load_preset_mappings(language: str) -> tuple[dict[str, str], dict[str, str]
     for lang in (language, language.split("-", maxsplit=1)[0], "en"):
         lang_file = TRANSLATIONS_PATH / f"{lang}.json"
         if lang_file.is_file():
-            try:
+            with contextlib.suppress(OSError, json.JSONDecodeError):
                 with lang_file.open(encoding="utf-8") as f:
                     data = json.load(f)
                 display_map = data.get("selector", {}).get("presets", {}).get("options", {})
                 if display_map:
                     break
-            except Exception:  # noqa: BLE001
-                pass
 
     canonical_map = {v: k for k, v in display_map.items()}
     canonical_map.update({k: k for k in display_map})


### PR DESCRIPTION
Maps fan preset modes (sleep, breeze) to localized display names across all integration locales (cs, en, es, fr, hu, ru, sk, zh-Hans) using hass.config.language. This ensures HomeKit, voice assistants, and UI display natural names while keeping BLE codec commands 100% canonical and untouched.