### PR TITLE
Improve Spanish translation wording

### DIFF
--- a/custom_components/ble_adv/translations/es.json
+++ b/custom_components/ble_adv/translations/es.json
@@ -1,50 +1,50 @@
 {
-  "title": "Dispositivos controlados por BLE",
+  "title": "Dispositivos controlados por publicidad BLE",
   "config": {
     "step": {
       "user": {
-        "description": "Antes de empezar, acércate al dispositivo que quieres configurar.",
+        "description": "¡Antes de comenzar, asegúrate de estar en la misma habitación que el dispositivo que quieres controlar!",
         "menu_options": {
-          "wait_config": "Copiar la configuración desde la app del móvil (recomendado)",
-          "pair": "Emparejar dispositivo",
-          "tools": "Herramientas"
+          "wait_config": "Duplicar la configuración de la app del móvil emparejado (Recomendado)",
+          "pair": "Emparejamiento",
+          "tools": "Herramientas y utilidades"
         }
       },
       "no_adapters": {
-        "description": "No se ha encontrado ningún adaptador Bluetooth compatible con señales BLE.\nConsulta la [Guía de resolución de problemas - Paso 1.2]({url}).",
+        "description": "No se ha encontrado ningún adaptador Bluetooth compatible con publicidad BLE.\nPor favor, consulta la [Guía de resolución de problemas - Paso 1.2]({url}).",
         "menu_options": {
           "abort_no_adapters": "Cancelar",
           "open_issue": "Abrir incidencia"
         }
       },
       "tools": {
-        "title": "Herramientas",
-        "description": "Herramientas y opciones avanzadas.",
+        "title": "Herramientas y utilidades",
+        "description": "Sección de herramientas",
         "menu_options": {
-          "diag": "Descargar diagnóstico",
-          "manual": "Configuración manual (avanzada)",
-          "inject": "Enviar datos RAW",
-          "listen_raw": "Escuchar señales BLE",
-          "decode_raw": "Decodificar datos BLE RAW"
+          "diag": "Volcado de diagnóstico",
+          "manual": "Entrada manual (Experto)",
+          "inject": "Inyectar datos RAW",
+          "listen_raw": "Escuchar publicidad BLE",
+          "decode_raw": "Decodificar publicidad BLE RAW"
         }
       },
       "diag": {
-        "title": "Diagnóstico"
+        "title": "Volcado de diagnóstico"
       },
       "listen_raw": {
-        "title": "Escuchar señales BLE"
+        "title": "Escuchar publicidad BLE"
       },
       "listen_raw_res": {
-        "title": "Señales BLE recibidas",
-        "description": "Señales BLE recibidas:\n{advs}",
+        "title": "Escuchar publicidad BLE",
+        "description": "Publicidad BLE recibida:\n{advs}",
         "menu_options": {
-          "listen_raw": "Volver a escuchar",
+          "listen_raw": "Reintentar",
           "tools": "Volver a Herramientas"
         }
       },
       "inject": {
-        "title": "Envío manual",
-        "description": "Opción avanzada para enviar datos en bruto (RAW).",
+        "title": "Inyección manual",
+        "description": "Para usuarios avanzados, inyectar datos en bruto (RAW)",
         "data": {
           "adapter_id": "Adaptador BLE ADV",
           "raw": "Datos RAW",
@@ -53,30 +53,30 @@
         }
       },
       "inject_res": {
-        "title": "Resultado del envío",
-        "description": "Los datos se han enviado correctamente.",
+        "title": "Resultado de la inyección",
+        "description": "Inyección realizada.",
         "menu_options": {
-          "inject": "Enviar otros datos RAW",
+          "inject": "Inyectar nuevos datos RAW",
           "tools": "Volver a Herramientas"
         }
       },
       "decode_raw": {
-        "title": "Decodificar datos BLE RAW",
+        "title": "Decodificando publicidad BLE RAW",
         "data": {
           "raw": "Datos RAW"
         }
       },
       "decode_raw_res": {
-        "title": "Resultado de la decodificación BLE RAW",
+        "title": "Resultado del descifrado BLE ADV RAW",
         "description": "{conf}",
         "menu_options": {
-          "decode_raw": "Decodificar otros datos RAW",
+          "decode_raw": "Decodificar nuevos datos RAW",
           "tools": "Volver a Herramientas"
         }
       },
       "manual": {
-        "title": "Configuración manual",
-        "description": "Para usuarios avanzados, por ejemplo, si estás migrando desde ESPHome.",
+        "title": "Entrada manual",
+        "description": "Para usuarios experimentados, por ejemplo si migran desde ESPHome",
         "data": {
           "name": "Nombre del dispositivo",
           "codec_id": "Códec",
@@ -86,102 +86,102 @@
         }
       },
       "wait_config": {
-        "title": "Esperando la configuración de la app del móvil..."
+        "title": "Escuchando configuración desde la app del móvil emparejado."
       },
       "no_config": {
-        "description": "No se ha detectado ninguna configuración en 10 segundos.",
+        "description": "No se detectó ninguna configuración en 10 segundos",
         "menu_options": {
-          "wait_config": "Volver a intentarlo",
+          "wait_config": "Reintentar",
           "abort_config": "Cancelar",
           "open_issue": "Abrir incidencia"
         }
       },
       "test_light": {
-        "title": "Probar configuración"
+        "title": "Prueba de configuración"
       },
       "test_fan": {
-        "title": "Probar configuración"
+        "title": "Prueba de configuración"
       },
       "pair": {
-        "title": "Emparejar dispositivo",
-        "description": "Selecciona el adaptador Bluetooth y la app del móvil. Después, apaga el dispositivo y vuelve a encenderlo. Pulsa **Enviar** antes de que pasen 5 segundos para iniciar el emparejamiento.",
+        "title": "Emparejamiento",
+        "description": "Selecciona el adaptador Bluetooth relevante y la aplicación móvil en las listas de abajo. Corta la corriente del dispositivo, vuelve a conectarla y pulsa el botón **Enviar** antes de 5 segundos (esto enviará las órdenes de emparejamiento)",
         "data": {
           "adapter_id": "Adaptador BLE ADV",
-          "phone_app": "App del móvil"
+          "phone_app": "Aplicación móvil"
         }
       },
       "wait_pair": {
-        "title": "Emparejando dispositivo..."
+        "title": "Emparejamiento"
       },
       "confirm_pair": {
-        "description": "¿Se ha emparejado correctamente? Normalmente la luz parpadea cuando funciona, aunque puede variar según el dispositivo.",
+        "description": "¿El emparejamiento fue correcto? Por lo general la luz parpadea si ha funcionado, aunque depende del tipo de luz...",
         "menu_options": {
-          "pair": "No se ha emparejado. Volver a intentarlo",
-          "confirm_no_abort": "No se ha emparejado. Cancelar",
-          "blink": "Se ha emparejado. Probar configuración"
+          "pair": "Emparejamiento FALLIDO, reintentar",
+          "confirm_no_abort": "Emparejamiento FALLIDO, cancelar",
+          "blink": "Emparejamiento CORRECTO, probar configuraciones"
         }
       },
       "choose_adapter": {
-        "title": "Elegir adaptador",
-        "description": "Varios adaptadores Bluetooth han detectado la configuración. Elige el que esté más cerca del dispositivo.",
+        "title": "Selección de adaptador",
+        "description": "Más de un adaptador Bluetooth ha detectado la configuración. Selecciona el más cercano a tu dispositivo",
         "data": {
           "adapter_id": "Adaptador BLE ADV"
         }
       },
       "confirm_light": {
-        "title": "Comprobar configuración",
-        "description": "Probando la configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}\n\n¿La luz ha parpadeado?",
+        "title": "Validación",
+        "description": "Probando configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}\n\n¿Ha parpadeado la luz?",
         "menu_options": {
-          "confirm_yes": "Sí",
-          "confirm_no_another": "No, probar la siguiente",
-          "confirm_no_abort": "No, cancelar",
-          "open_issue": "No, abrir una incidencia",
-          "confirm_retry_last": "Volver a probar esta configuración",
-          "confirm_retry_all": "Empezar de nuevo desde la primera",
-          "confirm_test_fan": "El dispositivo no tiene luz. Probar con el ventilador"
+          "confirm_yes": "¡Sí!",
+          "confirm_no_another": "No, probar siguiente.",
+          "confirm_no_abort": "No, cancelar.",
+          "open_issue": "No, abrir incidencia",
+          "confirm_retry_last": "Reintentar la misma.",
+          "confirm_retry_all": "Reintentar desde la primera.",
+          "confirm_test_fan": "Dispositivo sin luz; prueba con ventilador."
         }
       },
       "confirm_fan": {
-        "title": "Comprobar configuración",
-        "description": "Probando la configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}\n\n¿El ventilador se ha encendido o apagado?",
+        "title": "Validación",
+        "description": "Probando configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}\n\n¿El ventilador se puso en marcha o se detuvo?",
         "menu_options": {
-          "confirm_yes": "Sí",
-          "confirm_no_another": "No, probar la siguiente",
-          "confirm_no_abort": "No, cancelar",
-          "open_issue": "No, abrir una incidencia",
-          "confirm_retry_last": "Volver a probar esta configuración",
-          "confirm_retry_all": "Empezar de nuevo desde la primera"
+          "confirm_yes": "¡Sí!",
+          "confirm_no_another": "No, probar siguiente.",
+          "confirm_no_abort": "No, cancelar.",
+          "open_issue": "No, abrir incidencia",
+          "confirm_retry_last": "Reintentar la misma.",
+          "confirm_retry_all": "Reintentar desde la primera."
         }
       },
       "open_issue": {
-        "title": "Abrir una incidencia",
-        "description": "1. Descarga el archivo de diagnóstico con el botón de abajo.\n2. Abre una [incidencia]({url}) de Config Flow y adjunta el archivo.",
+        "title": "Abrir incidencia",
+        "description": "1. Descarga el volcado de diagnóstico haciendo clic en el botón de abajo\n2. Abre una [incidencia]({url}) de Config Flow y adjunta el archivo.",
         "menu_options": {
-          "diag": "Descargar diagnóstico"
+          "diag": "Descargar volcado de diagnóstico"
         }
       },
       "configure": {
         "title": "Configuración",
-        "description": "Configura las entidades, los mandos físicos y las opciones técnicas.\nPodrás cambiar estos ajustes más adelante desde la opción 'Reconfigurar'.",
+        "description": "Configurando entidades, mando físico y parámetros técnicos.\nEstos parámetros se pueden modificar más adelante mediante la opción 'Reconfigurar'.",
         "menu_options": {
-          "config_entities": "Configurar luces y ventiladores",
-          "config_remotes": "Configurar otro mando o controlador",
-          "config_technical": "Opciones técnicas",
+          "config_entities": "Configurar Luces / Ventiladores",
+          "config_remotes": "Configurar otro controlador (Mando físico, ...)",
+          "config_technical": "Parámetros técnicos",
           "finalize": "Finalizar"
         }
       },
       "config_entities": {
-        "title": "Luces y ventiladores",
-        "description": "Elige qué luces o ventiladores quieres añadir y configura sus opciones.",
+        "title": "Entidades controladas",
+        "description": "Selecciona las entidades que quieres crear y sus características",
         "sections": {
           "light_0": {
             "name": "Luz principal",
             "data": {
               "type": "Tipo",
               "min_brightness": "Brillo mínimo",
-              "refresh_on_start": "Actualizar color y brillo al encender",
-              "reversed": "Invertir frío y cálido",
-              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
+              "refresh_on_start": "Forzar refresco de color / brillo al ENCENDER",
+              "reversed": "Invertir Frío / Cálido",
+              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
               "effects": "Modos de luz"
             }
           },
@@ -190,9 +190,9 @@
             "data": {
               "type": "Tipo",
               "min_brightness": "Brillo mínimo",
-              "refresh_on_start": "Actualizar color y brillo al encender",
-              "reversed": "Invertir frío y cálido",
-              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
+              "refresh_on_start": "Forzar refresco de color / brillo al ENCENDER",
+              "reversed": "Invertir Frío / Cálido",
+              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
               "effects": "Modos de luz"
             }
           },
@@ -201,9 +201,9 @@
             "data": {
               "type": "Tipo",
               "min_brightness": "Brillo mínimo",
-              "refresh_on_start": "Actualizar color y brillo al encender",
-              "reversed": "Invertir frío y cálido",
-              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
+              "refresh_on_start": "Forzar refresco de color / brillo al ENCENDER",
+              "reversed": "Invertir Frío / Cálido",
+              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
               "effects": "Modos de luz"
             }
           },
@@ -211,43 +211,43 @@
             "name": "Ventilador principal",
             "data": {
               "type": "Tipo",
-              "direction": "Permite cambiar la dirección",
-              "oscillating": "Permite la oscilación",
-              "refresh_dir_on_start": "Actualizar la dirección al encender",
-              "refresh_osc_on_start": "Actualizar la oscilación al encender",
-              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
-              "presets": "Modos del ventilador"
+              "direction": "Admite cambio de sentido",
+              "oscillating": "Admite oscilación",
+              "refresh_dir_on_start": "Forzar refresco del sentido al ENCENDER",
+              "refresh_osc_on_start": "Forzar refresco de la oscilación al ENCENDER",
+              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
+              "presets": "Modos de ventilador"
             }
           },
           "fan_1": {
             "name": "Segundo ventilador",
             "data": {
               "type": "Tipo",
-              "direction": "Permite cambiar la dirección",
-              "oscillating": "Permite la oscilación",
-              "refresh_dir_on_start": "Actualizar la dirección al encender",
-              "refresh_osc_on_start": "Actualizar la oscilación al encender",
-              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
-              "presets": "Modos del ventilador"
+              "direction": "Admite cambio de sentido",
+              "oscillating": "Admite oscilación",
+              "refresh_dir_on_start": "Forzar refresco del sentido al ENCENDER",
+              "refresh_osc_on_start": "Forzar refresco de la oscilación al ENCENDER",
+              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
+              "presets": "Modos de ventilador"
             }
           },
           "fan_2": {
             "name": "Tercer ventilador",
             "data": {
               "type": "Tipo",
-              "direction": "Permite cambiar la dirección",
-              "oscillating": "Permite la oscilación",
-              "refresh_dir_on_start": "Actualizar la dirección al encender",
-              "refresh_osc_on_start": "Actualizar la oscilación al encender",
-              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
-              "presets": "Modos del ventilador"
+              "direction": "Admite cambio de sentido",
+              "oscillating": "Admite oscilación",
+              "refresh_dir_on_start": "Forzar refresco del sentido al ENCENDER",
+              "refresh_osc_on_start": "Forzar refresco de la oscilación al ENCENDER",
+              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
+              "presets": "Modos de ventilador"
             }
           }
         }
       },
       "config_remotes": {
-        "title": "Elegir controlador vinculado",
-        "description": "Elige el mando o controlador que quieres configurar.",
+        "title": "Seleccionar controlador vinculado",
+        "description": "Selecciona el controlador vinculado",
         "data": {
           "remote": "Controlador vinculado"
         }
@@ -256,68 +256,68 @@
         "title": "Configurar controlador vinculado",
         "description": "Controlador vinculado:\n\n    Nombre: {name}\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
         "menu_options": {
-          "config_remote_delete": "Eliminar este controlador",
-          "config_remote_update": "Cambiar las opciones del controlador",
+          "config_remote_delete": "Eliminar el controlador vinculado",
+          "config_remote_update": "Modificar las opciones del controlador vinculado",
           "configure": "Volver"
         }
       },
       "wait_config_remote": {
-        "title": "Configurar un nuevo controlador vinculado"
+        "title": "Configurar nuevo controlador vinculado"
       },
       "config_remote_update": {
         "title": "Opciones del controlador vinculado",
         "description": "Controlador vinculado:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
         "data": {
-          "paired": "Controla el dispositivo",
-          "tr_set": "Conjunto de traductores",
-          "name": "Nombre"
+          "name": "Nombre",
+          "paired": "Controlando el dispositivo",
+          "tr_set": "Conjunto de traductores"
         }
       },
       "config_technical": {
-        "title": "Opciones técnicas",
-        "description": "Cada comando se envía al adaptador seleccionado el número de veces indicado en 'Repeticiones', usando el 'Intervalo' configurado (ms) y respetando la 'Duración mínima' entre dos comandos distintos.\n\nCambia estos valores solo si sabes lo que estás haciendo.\n\nNo se recomienda utilizar varios adaptadores. Si lo haces, esta configuración no contará con soporte técnico.",
+        "title": "Configurar opciones técnicas",
+        "description": "Cada comando se emite al adaptador seleccionado 'Repeticiones' veces, en un 'Intervalo' determinado (ms), respetando un retardo de 'Duración mínima' entre 2 comandos distintos.\n\n¡Modifícalo solo si sabes lo que haces!\n\nSe DESACONSEJA SERIAMENTE usar múltiples adaptadores; no se prestará soporte técnico si lo haces.",
         "data": {
           "tr_set": "Conjunto de traductores",
-          "adapter_ids": "Adaptadores BLE ADV",
+          "adapter_ids": "Adaptador(es) BLE ADV",
           "interval": "Intervalo",
           "repeats": "Repeticiones",
           "duration": "Duración mínima"
         }
       },
       "finalize": {
-        "title": "Ponle un nombre al dispositivo",
-        "description": "Este es el último paso.",
+        "title": "Nombra tu dispositivo",
+        "description": "¡Este es el último paso!",
         "data": {
           "name": "Nombre del dispositivo"
         }
       }
     },
     "progress": {
-      "listen_raw": "Escuchando señales BLE...\n{advs}",
-      "wait_pair": "Emparejando dispositivo...",
-      "wait_config": "Pulsa cualquier botón de la app del móvil, preferiblemente el de emparejar, antes de {max_seconds}s.",
-      "agg_config": "Recopilando los datos de configuración...",
-      "test_light": "Probando la luz con la configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
-      "test_fan": "Probando el ventilador con la configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
-      "wait_config_remote": "Pulsa cualquier botón del mando, preferiblemente el de emparejar, antes de {max_seconds}s."
+      "listen_raw": "Escuchando publicidad BLE\n{advs}",
+      "wait_pair": "Emparejamiento en curso...",
+      "wait_config": "Pulsa cualquier botón (preferiblemente Emparejar) en la app del móvil antes de {max_seconds}s.",
+      "agg_config": "Agregando datos de configuración.",
+      "test_light": "Haciendo parpadear la luz con la configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
+      "test_fan": "Arranque / parada del ventilador con configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
+      "wait_config_remote": "Pulsa cualquier botón (preferiblemente Emparejar) en el mando antes de {max_seconds}s."
     },
     "abort": {
-      "no_adapters": "No se ha encontrado ningún adaptador Bluetooth compatible con señales BLE.",
-      "no_config": "No se ha encontrado ninguna configuración que funcione.",
-      "not_implemented": "Todavía no está disponible",
-      "reconfigure_successful": "La configuración se ha actualizado correctamente.",
-      "already_configured": "Ya hay un dispositivo configurado con la misma combinación de códec, ID e índice.\nConsulta la Guía de resolución de problemas - Paso 3.3 para obtener más información."
+      "no_adapters": "No se ha encontrado ningún adaptador Bluetooth compatible con publicidad BLE. Cancelando.",
+      "no_config": "No se ha descubierto ni probado con éxito ninguna configuración.",
+      "not_implemented": "No implementado (todavía)",
+      "reconfigure_successful": "¡Reconfiguración realizada con éxito!",
+      "already_configured": "Ya hay un dispositivo configurado con la misma combinación (códec / ID / índice).\nMás detalles en la Guía de resolución de problemas - Paso 3.3"
     },
     "error": {
-      "missing_entity": "Debes configurar al menos una luz o un ventilador.",
-      "missing_adapter": "Debes seleccionar al menos un adaptador."
+      "missing_entity": "Se debe configurar al menos un ventilador o una luz.",
+      "missing_adapter": "Se debe seleccionar al menos un adaptador."
     }
   },
   "selector": {
     "light": {
       "options": {
-        "cww": "Blanco frío y cálido",
-        "onoff": "Solo encendido y apagado",
+        "cww": "Blanco Frío / Cálido",
+        "onoff": "Solo Encendido / Apagado",
         "rgb": "RGB",
         "none": "Ninguno"
       }
@@ -345,7 +345,7 @@
     },
     "effects": {
       "options": {
-        "nm": "Modo Noche",
+        "nm": "Modo noche",
         "rgb": "Ciclo RGB",
         "rgbk": "Ciclo RGBK"
       }
@@ -359,11 +359,11 @@
     "tr_set": {
       "options": {
         "default": "Por defecto",
-        "rev_on_off": "Invertir encendido y apagado",
-        "fl": "Parpadeo",
-        "no_nm": "Sin Modo Noche",
-        "nm_as_effect": "Modo Noche como efecto",
-        "nm_as_second_light": "Modo Noche como segunda luz"
+        "rev_on_off": "Invertir ENCENDIDO/APAGADO",
+        "fl": "Parpadeante",
+        "no_nm": "Sin modo noche",
+        "nm_as_effect": "Modo noche como efecto",
+        "nm_as_second_light": "Modo noche como segunda luz"
       }
     }
   },
@@ -375,7 +375,7 @@
     },
     "switch": {
       "silent": {
-        "name": "Modo Sin Comandos"
+        "name": "Modo sin comandos"
       }
     },
     "fan": {
@@ -419,7 +419,7 @@
         "state_attributes": {
           "effect": {
             "state": {
-              "nm": "Modo Noche",
+              "nm": "Modo noche",
               "rgb": "Ciclo RGB",
               "rgbk": "Ciclo RGBK"
             }
@@ -431,7 +431,7 @@
         "state_attributes": {
           "effect": {
             "state": {
-              "nm": "Modo Noche",
+              "nm": "Modo noche",
               "rgb": "Ciclo RGB",
               "rgbk": "Ciclo RGBK"
             }
@@ -443,7 +443,7 @@
         "state_attributes": {
           "effect": {
             "state": {
-              "nm": "Modo Noche",
+              "nm": "Modo noche",
               "rgb": "Ciclo RGB",
               "rgbk": "Ciclo RGBK"
             }
@@ -454,32 +454,32 @@
   },
   "services": {
     "inject_raw": {
-      "name": "Enviar datos BLE ADV RAW",
-      "description": "Envía datos BLE en bruto (RAW) en formato hexadecimal.",
+      "name": "Inyectar BLE ADV RAW",
+      "description": "Inyectar publicidad BLE en bruto en formato hexadecimal binario.",
       "fields": {
         "adapter_id": {
           "name": "ID del adaptador",
-          "description": "Nombre del adaptador que se va a utilizar."
+          "description": "El nombre del adaptador que se va a utilizar."
         },
         "raw": {
           "name": "BLE ADV RAW",
-          "description": "Datos BLE en bruto que se van a enviar."
+          "description": "La emisión publicitaria BLE en bruto que se enviará."
         },
         "interval": {
           "name": "Intervalo",
-          "description": "Tiempo entre dos envíos, en milisegundos."
+          "description": "El intervalo entre 2 emisiones, en ms."
         },
         "repeat": {
           "name": "Repeticiones",
-          "description": "Número de veces que se enviarán los datos."
+          "description": "La emisión se enviará 'Repeticiones' veces."
         },
         "device_queue": {
           "name": "Nombre de la cola del dispositivo",
-          "description": "Nombre de la cola del dispositivo de destino. No es un ID; se utiliza para separar los envíos de distintos dispositivos y gestionar correctamente la cola."
+          "description": "El nombre de la cola del dispositivo objetivo, no corresponde a ningún ID: se usa para separar emisiones entre distintos dispositivos y aplicar la gestión de cola adecuada."
         },
         "duration": {
           "name": "Duración mínima",
-          "description": "Tiempo mínimo que debe pasar antes de poder enviar otra señal con el mismo adaptador y dispositivo, en milisegundos."
+          "description": "La duración mínima antes de poder enviar otra emisión con el mismo Adaptador/Dispositivo, en ms."
         }
       }
     }

--- a/custom_components/ble_adv/translations/es.json
+++ b/custom_components/ble_adv/translations/es.json
@@ -1,50 +1,50 @@
 {
-  "title": "Dispositivos controlados por publicidad BLE",
+  "title": "Dispositivos controlados por BLE",
   "config": {
     "step": {
       "user": {
-        "description": "¡Antes de comenzar, asegúrate de estar en la misma habitación que el dispositivo que quieres controlar!",
+        "description": "Antes de empezar, acércate al dispositivo que quieres configurar.",
         "menu_options": {
-          "wait_config": "Duplicar la configuración de la app del móvil emparejado (Recomendado)",
-          "pair": "Emparejamiento",
-          "tools": "Herramientas y utilidades"
+          "wait_config": "Copiar la configuración desde la app del móvil (recomendado)",
+          "pair": "Emparejar dispositivo",
+          "tools": "Herramientas"
         }
       },
       "no_adapters": {
-        "description": "No se ha encontrado ningún adaptador Bluetooth compatible con publicidad BLE.\nPor favor, consulta la [Guía de resolución de problemas - Paso 1.2]({url}).",
+        "description": "No se ha encontrado ningún adaptador Bluetooth compatible con señales BLE.\nConsulta la [Guía de resolución de problemas - Paso 1.2]({url}).",
         "menu_options": {
           "abort_no_adapters": "Cancelar",
           "open_issue": "Abrir incidencia"
         }
       },
       "tools": {
-        "title": "Herramientas y utilidades",
-        "description": "Sección de herramientas",
+        "title": "Herramientas",
+        "description": "Herramientas y opciones avanzadas.",
         "menu_options": {
-          "diag": "Volcado de diagnóstico",
-          "manual": "Entrada manual (Experto)",
-          "inject": "Inyectar datos RAW",
-          "listen_raw": "Escuchar publicidad BLE",
-          "decode_raw": "Decodificar publicidad BLE RAW"
+          "diag": "Descargar diagnóstico",
+          "manual": "Configuración manual (avanzada)",
+          "inject": "Enviar datos RAW",
+          "listen_raw": "Escuchar señales BLE",
+          "decode_raw": "Decodificar datos BLE RAW"
         }
       },
       "diag": {
-        "title": "Volcado de diagnóstico"
+        "title": "Diagnóstico"
       },
       "listen_raw": {
-        "title": "Escuchar publicidad BLE"
+        "title": "Escuchar señales BLE"
       },
       "listen_raw_res": {
-        "title": "Escuchar publicidad BLE",
-        "description": "Publicidad BLE recibida:\n{advs}",
+        "title": "Señales BLE recibidas",
+        "description": "Señales BLE recibidas:\n{advs}",
         "menu_options": {
-          "listen_raw": "Reintentar",
+          "listen_raw": "Volver a escuchar",
           "tools": "Volver a Herramientas"
         }
       },
       "inject": {
-        "title": "Inyección manual",
-        "description": "Para usuarios avanzados, inyectar datos en bruto (RAW)",
+        "title": "Envío manual",
+        "description": "Opción avanzada para enviar datos en bruto (RAW).",
         "data": {
           "adapter_id": "Adaptador BLE ADV",
           "raw": "Datos RAW",
@@ -53,135 +53,135 @@
         }
       },
       "inject_res": {
-        "title": "Resultado de la inyección",
-        "description": "Inyección realizada.",
+        "title": "Resultado del envío",
+        "description": "Los datos se han enviado correctamente.",
         "menu_options": {
-          "inject": "Inyectar nuevos datos RAW",
+          "inject": "Enviar otros datos RAW",
           "tools": "Volver a Herramientas"
         }
       },
       "decode_raw": {
-        "title": "Decodificando publicidad BLE RAW",
+        "title": "Decodificar datos BLE RAW",
         "data": {
           "raw": "Datos RAW"
         }
       },
       "decode_raw_res": {
-        "title": "Resultado del descifrado BLE ADV RAW",
+        "title": "Resultado de la decodificación BLE RAW",
         "description": "{conf}",
         "menu_options": {
-          "decode_raw": "Decodificar nuevos datos RAW",
+          "decode_raw": "Decodificar otros datos RAW",
           "tools": "Volver a Herramientas"
         }
       },
       "manual": {
-        "title": "Entrada manual",
-        "description": "Para usuarios experimentados, por ejemplo si migran desde ESPHome",
+        "title": "Configuración manual",
+        "description": "Para usuarios avanzados, por ejemplo, si estás migrando desde ESPHome.",
         "data": {
           "name": "Nombre del dispositivo",
           "codec_id": "Códec",
           "adapter_id": "Adaptador BLE ADV",
-          "forced_id": "ID forzada",
+          "forced_id": "ID forzado",
           "index": "Índice"
         }
       },
       "wait_config": {
-        "title": "Escuchando configuración desde la app del móvil emparejado."
+        "title": "Esperando la configuración de la app del móvil..."
       },
       "no_config": {
-        "description": "No se detectó ninguna configuración en 10 segundos",
+        "description": "No se ha detectado ninguna configuración en 10 segundos.",
         "menu_options": {
-          "wait_config": "Reintentar",
+          "wait_config": "Volver a intentarlo",
           "abort_config": "Cancelar",
           "open_issue": "Abrir incidencia"
         }
       },
       "test_light": {
-        "title": "Prueba de configuración"
+        "title": "Probar configuración"
       },
       "test_fan": {
-        "title": "Prueba de configuración"
+        "title": "Probar configuración"
       },
       "pair": {
-        "title": "Emparejamiento",
-        "description": "Selecciona el adaptador Bluetooth relevante y la aplicación móvil en las listas de abajo. Corta la corriente del dispositivo, vuelve a conectarla y pulsa el botón **Enviar** antes de 5 segundos (esto enviará las órdenes de emparejamiento)",
+        "title": "Emparejar dispositivo",
+        "description": "Selecciona el adaptador Bluetooth y la app del móvil. Después, apaga el dispositivo y vuelve a encenderlo. Pulsa **Enviar** antes de que pasen 5 segundos para iniciar el emparejamiento.",
         "data": {
           "adapter_id": "Adaptador BLE ADV",
-          "phone_app": "Aplicación móvil"
+          "phone_app": "App del móvil"
         }
       },
       "wait_pair": {
-        "title": "Emparejamiento"
+        "title": "Emparejando dispositivo..."
       },
       "confirm_pair": {
-        "description": "¿El emparejamiento fue correcto? Por lo general la luz parpadea si ha funcionado, aunque depende del tipo de luz...",
+        "description": "¿Se ha emparejado correctamente? Normalmente la luz parpadea cuando funciona, aunque puede variar según el dispositivo.",
         "menu_options": {
-          "pair": "Emparejamiento FALLIDO, reintentar",
-          "confirm_no_abort": "Emparejamiento FALLIDO, cancelar",
-          "blink": "Emparejamiento CORRECTO, probar configuraciones"
+          "pair": "No se ha emparejado. Volver a intentarlo",
+          "confirm_no_abort": "No se ha emparejado. Cancelar",
+          "blink": "Se ha emparejado. Probar configuración"
         }
       },
       "choose_adapter": {
-        "title": "Selección de adaptador",
-        "description": "Más de un adaptador Bluetooth ha detectado la configuración. Selecciona el más cercano a tu dispositivo",
+        "title": "Elegir adaptador",
+        "description": "Varios adaptadores Bluetooth han detectado la configuración. Elige el que esté más cerca del dispositivo.",
         "data": {
           "adapter_id": "Adaptador BLE ADV"
         }
       },
       "confirm_light": {
-        "title": "Validación",
-        "description": "Probando configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}\n\n¿Ha parpadeado la luz?",
+        "title": "Comprobar configuración",
+        "description": "Probando la configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}\n\n¿La luz ha parpadeado?",
         "menu_options": {
-          "confirm_yes": "¡Sí!",
-          "confirm_no_another": "No, probar siguiente.",
-          "confirm_no_abort": "No, cancelar.",
-          "open_issue": "No, abrir incidencia",
-          "confirm_retry_last": "Reintentar la misma.",
-          "confirm_retry_all": "Reintentar desde la primera.",
-          "confirm_test_fan": "Dispositivo sin luz; prueba con ventilador."
+          "confirm_yes": "Sí",
+          "confirm_no_another": "No, probar la siguiente",
+          "confirm_no_abort": "No, cancelar",
+          "open_issue": "No, abrir una incidencia",
+          "confirm_retry_last": "Volver a probar esta configuración",
+          "confirm_retry_all": "Empezar de nuevo desde la primera",
+          "confirm_test_fan": "El dispositivo no tiene luz. Probar con el ventilador"
         }
       },
       "confirm_fan": {
-        "title": "Validación",
-        "description": "Probando configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}\n\n¿El ventilador se puso en marcha o se detuvo?",
+        "title": "Comprobar configuración",
+        "description": "Probando la configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}\n\n¿El ventilador se ha encendido o apagado?",
         "menu_options": {
-          "confirm_yes": "¡Sí!",
-          "confirm_no_another": "No, probar siguiente.",
-          "confirm_no_abort": "No, cancelar.",
-          "open_issue": "No, abrir incidencia",
-          "confirm_retry_last": "Reintentar la misma.",
-          "confirm_retry_all": "Reintentar desde la primera."
+          "confirm_yes": "Sí",
+          "confirm_no_another": "No, probar la siguiente",
+          "confirm_no_abort": "No, cancelar",
+          "open_issue": "No, abrir una incidencia",
+          "confirm_retry_last": "Volver a probar esta configuración",
+          "confirm_retry_all": "Empezar de nuevo desde la primera"
         }
       },
       "open_issue": {
-        "title": "Abrir incidencia",
-        "description": "1. Descarga el volcado de diagnóstico haciendo clic en el botón de abajo\n2. Abre una [incidencia]({url}) de Config Flow y adjunta el archivo.",
+        "title": "Abrir una incidencia",
+        "description": "1. Descarga el archivo de diagnóstico con el botón de abajo.\n2. Abre una [incidencia]({url}) de Config Flow y adjunta el archivo.",
         "menu_options": {
-          "diag": "Descargar volcado de diagnóstico"
+          "diag": "Descargar diagnóstico"
         }
       },
       "configure": {
         "title": "Configuración",
-        "description": "Configurando entidades, mando físico y parámetros técnicos.\nEstos parámetros se pueden modificar más adelante mediante la opción 'Reconfigurar'.",
+        "description": "Configura las entidades, los mandos físicos y las opciones técnicas.\nPodrás cambiar estos ajustes más adelante desde la opción 'Reconfigurar'.",
         "menu_options": {
-          "config_entities": "Configurar Luces / Ventiladores",
-          "config_remotes": "Configurar otro controlador (Mando físico, ...)",
-          "config_technical": "Parámetros técnicos",
+          "config_entities": "Configurar luces y ventiladores",
+          "config_remotes": "Configurar otro mando o controlador",
+          "config_technical": "Opciones técnicas",
           "finalize": "Finalizar"
         }
       },
       "config_entities": {
-        "title": "Entidades controladas",
-        "description": "Selecciona las entidades que quieres crear y sus características",
+        "title": "Luces y ventiladores",
+        "description": "Elige qué luces o ventiladores quieres añadir y configura sus opciones.",
         "sections": {
           "light_0": {
             "name": "Luz principal",
             "data": {
               "type": "Tipo",
               "min_brightness": "Brillo mínimo",
-              "refresh_on_start": "Forzar refresco de color / brillo al ENCENDER",
-              "reversed": "Invertir Frío / Cálido",
-              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
+              "refresh_on_start": "Actualizar color y brillo al encender",
+              "reversed": "Invertir frío y cálido",
+              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
               "effects": "Modos de luz"
             }
           },
@@ -190,9 +190,9 @@
             "data": {
               "type": "Tipo",
               "min_brightness": "Brillo mínimo",
-              "refresh_on_start": "Forzar refresco de color / brillo al ENCENDER",
-              "reversed": "Invertir Frío / Cálido",
-              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
+              "refresh_on_start": "Actualizar color y brillo al encender",
+              "reversed": "Invertir frío y cálido",
+              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
               "effects": "Modos de luz"
             }
           },
@@ -201,9 +201,9 @@
             "data": {
               "type": "Tipo",
               "min_brightness": "Brillo mínimo",
-              "refresh_on_start": "Forzar refresco de color / brillo al ENCENDER",
-              "reversed": "Invertir Frío / Cálido",
-              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
+              "refresh_on_start": "Actualizar color y brillo al encender",
+              "reversed": "Invertir frío y cálido",
+              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
               "effects": "Modos de luz"
             }
           },
@@ -211,43 +211,43 @@
             "name": "Ventilador principal",
             "data": {
               "type": "Tipo",
-              "direction": "Admite cambio de sentido",
-              "oscillating": "Admite oscilación",
-              "refresh_dir_on_start": "Forzar refresco del sentido al ENCENDER",
-              "refresh_osc_on_start": "Forzar refresco de la oscilación al ENCENDER",
-              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
-              "presets": "Modos de ventilador"
+              "direction": "Permite cambiar la dirección",
+              "oscillating": "Permite la oscilación",
+              "refresh_dir_on_start": "Actualizar la dirección al encender",
+              "refresh_osc_on_start": "Actualizar la oscilación al encender",
+              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
+              "presets": "Modos del ventilador"
             }
           },
           "fan_1": {
             "name": "Segundo ventilador",
             "data": {
               "type": "Tipo",
-              "direction": "Admite cambio de sentido",
-              "oscillating": "Admite oscilación",
-              "refresh_dir_on_start": "Forzar refresco del sentido al ENCENDER",
-              "refresh_osc_on_start": "Forzar refresco de la oscilación al ENCENDER",
-              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
-              "presets": "Modos de ventilador"
+              "direction": "Permite cambiar la dirección",
+              "oscillating": "Permite la oscilación",
+              "refresh_dir_on_start": "Actualizar la dirección al encender",
+              "refresh_osc_on_start": "Actualizar la oscilación al encender",
+              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
+              "presets": "Modos del ventilador"
             }
           },
           "fan_2": {
             "name": "Tercer ventilador",
             "data": {
               "type": "Tipo",
-              "direction": "Admite cambio de sentido",
-              "oscillating": "Admite oscilación",
-              "refresh_dir_on_start": "Forzar refresco del sentido al ENCENDER",
-              "refresh_osc_on_start": "Forzar refresco de la oscilación al ENCENDER",
-              "forced_cmds": "Comandos enviados siempre, incluso si nada ha cambiado",
-              "presets": "Modos de ventilador"
+              "direction": "Permite cambiar la dirección",
+              "oscillating": "Permite la oscilación",
+              "refresh_dir_on_start": "Actualizar la dirección al encender",
+              "refresh_osc_on_start": "Actualizar la oscilación al encender",
+              "forced_cmds": "Enviar siempre los comandos, aunque no haya cambios",
+              "presets": "Modos del ventilador"
             }
           }
         }
       },
       "config_remotes": {
-        "title": "Seleccionar controlador vinculado",
-        "description": "Selecciona el controlador vinculado",
+        "title": "Elegir controlador vinculado",
+        "description": "Elige el mando o controlador que quieres configurar.",
         "data": {
           "remote": "Controlador vinculado"
         }
@@ -256,68 +256,68 @@
         "title": "Configurar controlador vinculado",
         "description": "Controlador vinculado:\n\n    Nombre: {name}\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
         "menu_options": {
-          "config_remote_delete": "Eliminar el controlador vinculado",
-          "config_remote_update": "Modificar las opciones del controlador vinculado",
+          "config_remote_delete": "Eliminar este controlador",
+          "config_remote_update": "Cambiar las opciones del controlador",
           "configure": "Volver"
         }
       },
       "wait_config_remote": {
-        "title": "Configurar nuevo controlador vinculado"
+        "title": "Configurar un nuevo controlador vinculado"
       },
       "config_remote_update": {
-        "title": "Configure options del controlador vinculado",
+        "title": "Opciones del controlador vinculado",
         "description": "Controlador vinculado:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
         "data": {
-          "name": "Nombre",
-          "paired": "Controlando el dispositivo",
-          "tr_set": "Conjunto de traductores"
+          "paired": "Controla el dispositivo",
+          "tr_set": "Conjunto de traductores",
+          "name": "Nombre"
         }
       },
       "config_technical": {
-        "title": "Configurar opciones técnicas",
-        "description": "Cada comando se emite al adaptador seleccionado 'Repeticiones' veces, en un 'Intervalo' determinado (ms), respetando un retardo de 'Duración mínima' entre 2 comandos distintos.\n\n¡Modifícalo solo si sabes lo que haces!\n\nSe DESACONSEJA SERIAMENTE usar múltiples adaptadores; no se prestará soporte técnico si lo haces.",
+        "title": "Opciones técnicas",
+        "description": "Cada comando se envía al adaptador seleccionado el número de veces indicado en 'Repeticiones', usando el 'Intervalo' configurado (ms) y respetando la 'Duración mínima' entre dos comandos distintos.\n\nCambia estos valores solo si sabes lo que estás haciendo.\n\nNo se recomienda utilizar varios adaptadores. Si lo haces, esta configuración no contará con soporte técnico.",
         "data": {
           "tr_set": "Conjunto de traductores",
-          "adapter_ids": "Adaptador(es) BLE ADV",
+          "adapter_ids": "Adaptadores BLE ADV",
           "interval": "Intervalo",
           "repeats": "Repeticiones",
           "duration": "Duración mínima"
         }
       },
       "finalize": {
-        "title": "Nombra tu dispositivo",
-        "description": "¡Este es el último paso!",
+        "title": "Ponle un nombre al dispositivo",
+        "description": "Este es el último paso.",
         "data": {
           "name": "Nombre del dispositivo"
         }
       }
     },
     "progress": {
-      "listen_raw": "Escuchando publicidad BLE\n{advs}",
-      "wait_pair": "Emparejamiento en curso...",
-      "wait_config": "Pulsa cualquier botón (preferiblemente Emparejar) en la app del móvil antes de {max_seconds}s.",
-      "agg_config": "Agregando datos de configuración.",
-      "test_light": "Haciendo parpadear la luz con la configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
-      "test_fan": "Arranque / parada del ventilador con configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
-      "wait_config_remote": "Pulsa cualquier botón (preferiblemente Emparejar) en el mando antes de {max_seconds}s."
+      "listen_raw": "Escuchando señales BLE...\n{advs}",
+      "wait_pair": "Emparejando dispositivo...",
+      "wait_config": "Pulsa cualquier botón de la app del móvil, preferiblemente el de emparejar, antes de {max_seconds}s.",
+      "agg_config": "Recopilando los datos de configuración...",
+      "test_light": "Probando la luz con la configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
+      "test_fan": "Probando el ventilador con la configuración {nb}/{tot}:\n\n    Códec: {codec}\n    ID: {id}\n    Índice: {index}",
+      "wait_config_remote": "Pulsa cualquier botón del mando, preferiblemente el de emparejar, antes de {max_seconds}s."
     },
     "abort": {
-      "no_adapters": "No se ha encontrado ningún adaptador Bluetooth compatible con publicidad BLE. Cancelando.",
-      "no_config": "No se ha descubierto ni probado con éxito ninguna configuración.",
-      "not_implemented": "No implementado (todavía)",
-      "reconfigure_successful": "¡Reconfiguración realizada con éxito!",
-      "already_configured": "Ya hay un dispositivo configurado con la misma combinación (códec / ID / índice).\nMás detalles en la Guía de resolución de problemas - Paso 3.3"
+      "no_adapters": "No se ha encontrado ningún adaptador Bluetooth compatible con señales BLE.",
+      "no_config": "No se ha encontrado ninguna configuración que funcione.",
+      "not_implemented": "Todavía no está disponible",
+      "reconfigure_successful": "La configuración se ha actualizado correctamente.",
+      "already_configured": "Ya hay un dispositivo configurado con la misma combinación de códec, ID e índice.\nConsulta la Guía de resolución de problemas - Paso 3.3 para obtener más información."
     },
     "error": {
-      "missing_entity": "Se debe configurar al menos un ventilador o una luz.",
-      "missing_adapter": "Se debe seleccionar al menos un adaptador."
+      "missing_entity": "Debes configurar al menos una luz o un ventilador.",
+      "missing_adapter": "Debes seleccionar al menos un adaptador."
     }
   },
   "selector": {
     "light": {
       "options": {
-        "cww": "Blanco Frío / Cálido",
-        "onoff": "Solo Encendido / Apagado",
+        "cww": "Blanco frío y cálido",
+        "onoff": "Solo encendido y apagado",
         "rgb": "RGB",
         "none": "Ninguno"
       }
@@ -345,7 +345,7 @@
     },
     "effects": {
       "options": {
-        "nm": "Modo noche",
+        "nm": "Modo Noche",
         "rgb": "Ciclo RGB",
         "rgbk": "Ciclo RGBK"
       }
@@ -353,17 +353,17 @@
     "presets": {
       "options": {
         "breeze": "Modo Brisa",
-        "sleep": "Modo dormir"
+        "sleep": "Modo Sueño"
       }
     },
     "tr_set": {
       "options": {
         "default": "Por defecto",
-        "rev_on_off": "Invertir ENCENDIDO/APAGADO",
-        "fl": "Parpadeante",
-        "no_nm": "Sin modo noche",
-        "nm_as_effect": "Modo noche como efecto",
-        "nm_as_second_light": "Modo noche como segunda luz"
+        "rev_on_off": "Invertir encendido y apagado",
+        "fl": "Parpadeo",
+        "no_nm": "Sin Modo Noche",
+        "nm_as_effect": "Modo Noche como efecto",
+        "nm_as_second_light": "Modo Noche como segunda luz"
       }
     }
   },
@@ -375,7 +375,7 @@
     },
     "switch": {
       "silent": {
-        "name": "Modo sin comandos"
+        "name": "Modo Sin Comandos"
       }
     },
     "fan": {
@@ -385,7 +385,7 @@
           "preset_mode": {
             "state": {
               "breeze": "Modo Brisa",
-              "sleep": "Modo dormir"
+              "sleep": "Modo Sueño"
             }
           }
         }
@@ -396,7 +396,7 @@
           "preset_mode": {
             "state": {
               "breeze": "Modo Brisa",
-              "sleep": "Modo dormir"
+              "sleep": "Modo Sueño"
             }
           }
         }
@@ -407,7 +407,7 @@
           "preset_mode": {
             "state": {
               "breeze": "Modo Brisa",
-              "sleep": "Modo dormir"
+              "sleep": "Modo Sueño"
             }
           }
         }
@@ -419,7 +419,7 @@
         "state_attributes": {
           "effect": {
             "state": {
-              "nm": "Modo noche",
+              "nm": "Modo Noche",
               "rgb": "Ciclo RGB",
               "rgbk": "Ciclo RGBK"
             }
@@ -431,7 +431,7 @@
         "state_attributes": {
           "effect": {
             "state": {
-              "nm": "Modo noche",
+              "nm": "Modo Noche",
               "rgb": "Ciclo RGB",
               "rgbk": "Ciclo RGBK"
             }
@@ -443,7 +443,7 @@
         "state_attributes": {
           "effect": {
             "state": {
-              "nm": "Modo noche",
+              "nm": "Modo Noche",
               "rgb": "Ciclo RGB",
               "rgbk": "Ciclo RGBK"
             }
@@ -454,32 +454,32 @@
   },
   "services": {
     "inject_raw": {
-      "name": "Inyectar BLE ADV RAW",
-      "description": "Inyectar publicidad BLE en bruto en formato hexadecimal binario.",
+      "name": "Enviar datos BLE ADV RAW",
+      "description": "Envía datos BLE en bruto (RAW) en formato hexadecimal.",
       "fields": {
         "adapter_id": {
           "name": "ID del adaptador",
-          "description": "El nombre del adaptador que se va a utilizar."
+          "description": "Nombre del adaptador que se va a utilizar."
         },
         "raw": {
           "name": "BLE ADV RAW",
-          "description": "La emisión publicitaria BLE en bruto que se enviará."
+          "description": "Datos BLE en bruto que se van a enviar."
         },
         "interval": {
           "name": "Intervalo",
-          "description": "El intervalo entre 2 emisiones, en ms."
+          "description": "Tiempo entre dos envíos, en milisegundos."
         },
         "repeat": {
           "name": "Repeticiones",
-          "description": "La emisión se enviará 'Repeticiones' veces."
+          "description": "Número de veces que se enviarán los datos."
         },
         "device_queue": {
           "name": "Nombre de la cola del dispositivo",
-          "description": "El nombre de la cola del dispositivo objetivo, no corresponde a ningún ID: se usa para separar emisiones entre distintos dispositivos y aplicar la gestión de cola adecuada."
+          "description": "Nombre de la cola del dispositivo de destino. No es un ID; se utiliza para separar los envíos de distintos dispositivos y gestionar correctamente la cola."
         },
         "duration": {
           "name": "Duración mínima",
-          "description": "La duración mínima antes de poder enviar otra emisión con el mismo Adaptador/Dispositivo, en ms."
+          "description": "Tiempo mínimo que debe pasar antes de poder enviar otra señal con el mismo adaptador y dispositivo, en milisegundos."
         }
       }
     }


### PR DESCRIPTION
## Description

Improve the existing Spanish translation of BLE ADV to make the wording more natural, clear and consistent for native Spanish speakers.

Main changes:
- Improve the wording of several configuration and service descriptions.
- Translate the remaining "Configure options" text.
- Use consistent names for "Modo Noche", "Modo Brisa" and "Modo Sueño".
- Keep all existing translation keys and placeholders unchanged.
- No Python code, BLE commands, entity behavior or integration logic has been modified.

Related to #293, where the Spanish translation was originally added to BLE ADV.

## 🧪 Change Type

- [ ] 🐛 Bug Fix
- [ ] ✨ New Feature
- [ ] 🚀 Perf improvement / Refactoring
- [ ] ✨ New codec
- [x] 📝 Documentation

## 📋 Checklist

- [ ] Once opened, I will link the Issue where this change was discussed and approved by the maintainer
- [x] I read the [Contribution Guidelines](../CONTRIBUTING.md) of the project and this change fully complies with them.
- [ ] I tested my software on a live HA server
- [ ] I added Unit Tests to test my new software
- [ ] I ran the existing Tests and all are OK